### PR TITLE
[#28] [Backend] As a User, I can reset my password via the Web UI 

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.


### PR DESCRIPTION
- #28 

## What happened

Devise is already 99% configured, so not much to change in here! 
As recommended by Samuel [here](https://www.notion.so/nimblehq/Devise-Login-Sign-up-and-Forgot-Password-beb2550a041d4c8f818250afed15d237), I just activated the Paranoid mode.

This prevents unauthenticated user to "guess" if an account exists or not.

## Insight

Devise initialization, I uncommented 1 line ;-)
```ruby
config.paranoid = true
```

The whole password reset feature is provided by Devise gem.

## Proof Of Work

| Reset password form | If maching email, sends the reset password message | In any case, display the message bellow: |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/123094341-f9e8ed80-d456-11eb-93c6-16341a92c066.png) | ![image](https://user-images.githubusercontent.com/77609814/123094232-dde54c00-d456-11eb-8b9e-56478f875e00.png) | ![image](https://user-images.githubusercontent.com/77609814/123093490-f739c880-d455-11eb-9101-803affcc67fc.png) |
