### PR TITLE
[#25] [API] As a User, I can see a list of my previous keywords

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -22,10 +22,6 @@ module API
 
       private
 
-      def render_empty(meta_message)
-        render json: { meta: meta_message, data: [] }
-      end
-
       # helper method to access the current user from the token
       def current_user
         @current_user ||= User.find_by(id: doorkeeper_token[:resource_owner_id])

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -14,7 +14,7 @@ module API
 
       rescue_from ::Pagy::OverflowError do |e|
         render_error(
-          details: "#{I18n.t('pagy.errors.overflow')} #{e.pagy.last}",
+          details: I18n.t('pagy.errors.overflow', max_page: e.pagy.last),
           source: e.variable,
           status: :unprocessable_entity
         )

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -3,8 +3,22 @@
 module API
   module V1
     class ApplicationController < ActionController::API
+      include ErrorHandlerConcern
+
       # equivalent of authenticate_user! on devise, but this one will check the oauth token
       before_action :doorkeeper_authorize!
+
+      rescue_from ::Pagy::VariableError do |e|
+        render_error(details: I18n.t('pagy.errors.variable'), source: e.variable, status: :unprocessable_entity)
+      end
+
+      rescue_from ::Pagy::OverflowError do |e|
+        render_error(
+          details: "#{I18n.t('pagy.errors.overflow')} #{e.pagy.last}",
+          source: e.variable,
+          status: :unprocessable_entity
+        )
+      end
 
       private
 

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -22,6 +22,10 @@ module API
 
       private
 
+      def render_empty(meta_message)
+        render json: { meta: meta_message, data: [] }
+      end
+
       # helper method to access the current user from the token
       def current_user
         @current_user ||= User.find_by(id: doorkeeper_token[:resource_owner_id])

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -9,11 +9,7 @@ module API
       def index
         pagy, keywords_list = pagy(keywords)
 
-        if keywords.any?
-          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
-        else
-          render_empty I18n.t('keywords.empty_list')
-        end
+        render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
       end
 
       private

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -10,7 +10,7 @@ module API
         pagy, keywords_list = pagy(keywords)
 
         if keywords.any?
-          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy)).serializable_hash, status: :ok
+          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy)).serializable_hash
         else
           render_empty
         end
@@ -19,7 +19,7 @@ module API
       private
 
       def render_empty
-        render json: { meta: I18n.t('keywords.empty_list'), data: [] }, status: :ok
+        render json: { meta: I18n.t('keywords.empty_list'), data: [] }
       end
 
       def keywords

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class KeywordsController < ApplicationController
+      include ::Pagy::Backend
+      include API::V1::Pagy::JSONAPIConcern
+      include ErrorHandlerConcern
+
+      def index
+        pagy, keywords = pagy(KeywordsQuery.new(current_user).call)
+
+        if keywords.any?
+          render json: KeywordSerializer.new(keywords, pagy_options(pagy)).serializable_hash, status: :ok
+        else
+          render_empty
+        end
+      rescue ::Pagy::OverflowError => e
+        rescue_page_error("#{I18n.t('pagy.errors.overflow')} #{e.pagy.last}", e)
+      rescue ::Pagy::VariableError => e
+        rescue_page_error(I18n.t('pagy.errors.variable'), e)
+      end
+
+      private
+
+      def rescue_page_error(message, error)
+        render_error(details: message, source: error.variable, status: :unprocessable_entity)
+      end
+
+      def render_empty
+        render json: { meta: I18n.t('keywords.empty_list'), data: [] }, status: :ok
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -12,15 +12,11 @@ module API
         if keywords.any?
           render json: KeywordSerializer.new(keywords_list, pagy_options(pagy)).serializable_hash
         else
-          render_empty
+          render_empty I18n.t('keywords.empty_list')
         end
       end
 
       private
-
-      def render_empty
-        render json: { meta: I18n.t('keywords.empty_list'), data: [] }
-      end
 
       def keywords
         KeywordsQuery.new(current_user).call

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -5,7 +5,6 @@ module API
     class KeywordsController < ApplicationController
       include ::Pagy::Backend
       include API::V1::Pagy::JSONAPIConcern
-      include ErrorHandlerConcern
 
       def index
         pagy, keywords_list = pagy(keywords)
@@ -15,17 +14,9 @@ module API
         else
           render_empty
         end
-      rescue ::Pagy::OverflowError => e
-        rescue_page_error("#{I18n.t('pagy.errors.overflow')} #{e.pagy.last}", e)
-      rescue ::Pagy::VariableError => e
-        rescue_page_error(I18n.t('pagy.errors.variable'), e)
       end
 
       private
-
-      def rescue_page_error(message, error)
-        render_error(details: message, source: error.variable, status: :unprocessable_entity)
-      end
 
       def render_empty
         render json: { meta: I18n.t('keywords.empty_list'), data: [] }, status: :ok

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -10,7 +10,7 @@ module API
         pagy, keywords_list = pagy(keywords)
 
         if keywords.any?
-          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy)).serializable_hash
+          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
         else
           render_empty I18n.t('keywords.empty_list')
         end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -8,10 +8,10 @@ module API
       include ErrorHandlerConcern
 
       def index
-        pagy, keywords = pagy(KeywordsQuery.new(current_user).call)
+        pagy, keywords_list = pagy(keywords)
 
         if keywords.any?
-          render json: KeywordSerializer.new(keywords, pagy_options(pagy)).serializable_hash, status: :ok
+          render json: KeywordSerializer.new(keywords_list, pagy_options(pagy)).serializable_hash, status: :ok
         else
           render_empty
         end
@@ -29,6 +29,10 @@ module API
 
       def render_empty
         render json: { meta: I18n.t('keywords.empty_list'), data: [] }, status: :ok
+      end
+
+      def keywords
+        KeywordsQuery.new(current_user).call
       end
     end
   end

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -3,8 +3,6 @@
 module API
   module V1
     class TokensController < Doorkeeper::TokensController
-      include ErrorHandlerConcern
-
       # Overridden from doorkeeper as the doorkeeper revoke action does not return response according to json-api spec
       def revoke
         # The authorization server responds with HTTP status code 200 if the client

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,8 +3,6 @@
 module API
   module V1
     class UsersController < ApplicationController
-      include API::V1::ErrorHandlerConcern
-
       skip_before_action :doorkeeper_authorize!, only: :create
 
       before_action :ensure_valid_client, only: :create

--- a/app/controllers/concerns/api/v1/pagy/jsonapi_concern.rb
+++ b/app/controllers/concerns/api/v1/pagy/jsonapi_concern.rb
@@ -26,7 +26,7 @@ module API
         def url_for_page(page)
           return nil unless page
 
-          url_for only_path: false, params: jsonapi_params.merge({ page: page })
+          url_for only_path: false, params: jsonapi_params.merge(page: page)
         end
 
         def jsonapi_params

--- a/app/controllers/concerns/api/v1/pagy/jsonapi_concern.rb
+++ b/app/controllers/concerns/api/v1/pagy/jsonapi_concern.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module Pagy
+      module JSONAPIConcern
+        private
+
+        def pagy_options(pagy)
+          {
+            meta: { total_pages: pagy.pages },
+            links: pagy_options_links(pagy)
+          }
+        end
+
+        def pagy_options_links(pagy)
+          {
+            first: url_for_page(1),
+            self: url_for_page(pagy.page),
+            next: url_for_page(pagy.next),
+            prev: url_for_page(pagy.prev),
+            last: url_for_page(pagy.last)
+          }
+        end
+
+        def url_for_page(page)
+          return nil unless page
+
+          url_for only_path: false, params: jsonapi_params.merge({ page: page })
+        end
+
+        def jsonapi_params
+          params.permit(:page, :sort, :filter)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class KeywordSerializer
+  include JSONAPI::Serializer
+
+  attributes :name
+end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -3,5 +3,5 @@
 class KeywordSerializer
   include JSONAPI::Serializer
 
-  attributes :name
+  attributes :name, :created_at
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,4 +16,6 @@
 # end
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'API'
+  inflect.acronym 'JSON'
+  inflect.acronym 'JSONAPI'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
     empty_list: 'You do not have any keyword yet.'
   pagy:
     errors:
-      overflow: 'There are not that many pages here! Max page is '
+      overflow: 'There are not that many pages here! Max page is %{max_page}'
       variable: 'The page you try to access does not exist.'
   auth:
     logout: 'Sign out'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,11 @@ en:
     token_revoked: 'If your token was valid, it has been revoked'
   keywords:
     could_not_query: 'An error occurs when performing the Google Search, please try again.'
+    empty_list: 'You do not have any keyword yet.'
+  pagy:
+    errors:
+      overflow: 'There are not that many pages here! Max page is '
+      variable: 'The page you try to access does not exist.'
   auth:
     logout: 'Sign out'
     sign_up: 'Sign up'
@@ -49,5 +54,3 @@ en:
   waiting_confirmation_for: 'Currently waiting confirmation for'
   forgot_password: 'Forgot your password?'
   my_profile: 'My Profile'
-  keywords:
-    empty_list: 'You do not have any keyword yet.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # User sign_up
-      resources :users, only: %i[create]
+      resources :users, only: :create
+      resources :keywords, only: :index
 
       # OAuth2 (token, revoke, ...)
       use_doorkeeper do

--- a/spec/fabricators/access_token_fabricator.rb
+++ b/spec/fabricators/access_token_fabricator.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Fabricator(:access_token, from: 'Doorkeeper::AccessToken')

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -66,7 +66,7 @@ describe API::V1::KeywordsController, type: :request do
     end
 
     context 'given a valid page param' do
-      it 'returns the keywords to that page' do
+      it 'returns the keywords for that page' do
         user = Fabricate(:user)
         Fabricate.times(51, :keyword, user: user)
 
@@ -79,7 +79,7 @@ describe API::V1::KeywordsController, type: :request do
     end
 
     context 'given an invalid page param' do
-      it 'returns a 422 Unprocessable Entity' do
+      it 'returns a 422 Unprocessable Entity status code' do
         user = Fabricate(:user)
         Fabricate.times(51, :keyword, user: user)
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -13,14 +13,6 @@ describe API::V1::KeywordsController, type: :request do
     end
 
     context 'when keyword_list is empty' do
-      it 'returns a meta message' do
-        create_token_header(Fabricate(:user))
-
-        get :index
-
-        expect(JSON.parse(response.body)['meta']).to eq(I18n.t('keywords.empty_list'))
-      end
-
       it 'returns an empty data array' do
         create_token_header(Fabricate(:user))
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe API::V1::KeywordsController, type: :request do
+  describe '#index' do
+    context 'given an unauthenticated user' do
+      it 'returns a 401 status code' do
+        get :index
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when no keywords' do
+      it 'returns a meta message' do
+        create_token_header(Fabricate(:user))
+
+        get :index
+
+        expect(JSON.parse(response.body)['meta']).to eq(I18n.t('keywords.empty_list'))
+      end
+
+      it 'returns an empty data array' do
+        create_token_header(Fabricate(:user))
+
+        get :index
+
+        expect(JSON.parse(response.body)['data'].count).to eq(0)
+      end
+    end
+
+    context 'when more than a page of keywords' do
+      it 'returns the first page of keywords' do
+        user = Fabricate(:user)
+        Fabricate.times(51, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(JSON.parse(response.body)['data'].count).to eq(50)
+      end
+
+      it 'returns the total pages meta info' do
+        user = Fabricate(:user)
+        Fabricate.times(51, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(JSON.parse(response.body)['meta']['total_pages']).to eq(2)
+      end
+
+      it 'returns the links to related pages' do
+        user = Fabricate(:user)
+        Fabricate.times(51, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(JSON.parse(response.body)['links'].keys).to contain_exactly('self', 'first', 'prev', 'next', 'last')
+      end
+    end
+
+    context 'given a valid page param' do
+      it 'returns the keywords to that page' do
+        user = Fabricate(:user)
+        Fabricate.times(51, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index, params: { page: 2 }
+
+        expect(JSON.parse(response.body)['data'].count).to eq(1)
+      end
+    end
+
+    context 'given an invalid page param' do
+      it 'returns a 422 Unprocessable Entity' do
+        user = Fabricate(:user)
+        Fabricate.times(51, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index, params: { page: 10 }
+
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe API::V1::KeywordsController, type: :request do
-  describe '#index' do
+  describe 'GET #index' do
     context 'given an unauthenticated user' do
       it 'returns a 401 status code' do
         get :index

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -12,7 +12,7 @@ describe API::V1::KeywordsController, type: :request do
       end
     end
 
-    context 'when no keywords' do
+    context 'when keyword_list is empty' do
       it 'returns a meta message' do
         create_token_header(Fabricate(:user))
 

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -57,4 +57,11 @@ module OAuthHelpers
       client_secret: @application.secret
     }
   end
+
+  def create_token_header(user)
+    application = Fabricate(:application)
+    access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
+
+    request.headers['Authorization'] = "Bearer #{access_token.token}"
+  end
 end


### PR DESCRIPTION
- #25

## What happened

Expose keywords list to API

## Insight

Basic keyword list (name/id only).
- Pagination implemented with Pagy
- Pagination made JSON::API compliant with this concern: `Pagy::JSONAPIConcern`
- API Endpoints [documented here](https://documenter.getpostman.com/view/16135891/TzeTKqCb)

## Proof Of Work

| Returns data as an array. Include pagination. | Error page overflow / Error invalid page |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/123395347-4d2f7d00-d5ca-11eb-9e40-d97ae56e7fb6.png) | ![image](https://user-images.githubusercontent.com/77609814/123395634-9ed80780-d5ca-11eb-962b-ef29621ef43a.png) | 
| ![image](https://user-images.githubusercontent.com/77609814/123395448-6c2e0f00-d5ca-11eb-8830-9b7a75828deb.png) | ![image](https://user-images.githubusercontent.com/77609814/123395678-ac8d8d00-d5ca-11eb-976b-baa7f91844fd.png) | 


