### PR TITLE
[#48] [FrontEnd] Bug - Layout is not responsive

### DIFF
--- a/app/assets/stylesheets/layouts/default.scss
+++ b/app/assets/stylesheets/layouts/default.scss
@@ -1,7 +1,6 @@
 .layout-default {
   .app-footer {
     width: 100%;
-    height: 60px;
     margin-top: 2rem;
     line-height: 60px;
     background-color: $gray-100;

--- a/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
@@ -16,7 +16,7 @@
 @import 'bootstrap/scss/buttons';
 //@import 'bootstrap/scss/tables';
 //@import 'bootstrap/scss/code';
-//@import 'bootstrap/scss/transitions';
+@import 'bootstrap/scss/transitions';
 @import 'bootstrap/scss/dropdown';
 @import 'bootstrap/scss/button-group';
 @import 'bootstrap/scss/input-group';


### PR DESCRIPTION
- #48 

## What happened

Fix 
- nav bar not hidden on mobile screen
- footer content overflow outside from footer for very small screens

## Insight

Nav bar:
While optimizing bootstrap scss includes, I removed "transition" which is used to open the hamburger menu.

Footer:
60px height was redundant with the line height, preventing the footer to extend in case the small text needs to span over 2 lines.

## Proof Of Work

| Before | After | 
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/123728215-253b6480-d8bd-11eb-8e86-241054057d3b.png) | ![image](https://user-images.githubusercontent.com/77609814/123728114-fd4c0100-d8bc-11eb-9af5-3fc02a559542.png) | 
| ![image](https://user-images.githubusercontent.com/77609814/123728246-2ff5f980-d8bd-11eb-931f-7a9208e25449.png) | ![image](https://user-images.githubusercontent.com/77609814/123728136-076dff80-d8bd-11eb-8ec0-01b8b43f77ca.png) |


