### PR TITLE
[#13] [Frontend] As a User, I can upload a csv file in order to run multiple keyword searches

### DIFF
--- a/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
@@ -20,7 +20,7 @@
 @import 'bootstrap/scss/dropdown';
 @import 'bootstrap/scss/button-group';
 @import 'bootstrap/scss/input-group';
-//@import 'bootstrap/scss/custom-forms';
+@import 'bootstrap/scss/custom-forms';
 @import 'bootstrap/scss/nav';
 @import 'bootstrap/scss/navbar';
 @import 'bootstrap/scss/card';

--- a/app/forms/csv_upload_form.rb
+++ b/app/forms/csv_upload_form.rb
@@ -25,7 +25,7 @@ class CSVUploadForm
         # rubocop:enable Rails/SkipsModelValidations
       end
     rescue ActiveRecord::StatementInvalid
-      errors.add(:keyword, I18n.t('csv.validation.bad_keyword_length'))
+      errors.add(:base, I18n.t('csv.validation.bad_keyword_length'))
     end
 
     errors.empty?

--- a/app/javascript/components/CSVUploadForm/index.js
+++ b/app/javascript/components/CSVUploadForm/index.js
@@ -5,7 +5,7 @@ const SELECTORS = {
 class CSVUploadForm {
   constructor(csvUploadForm) {
     this.csvUploadForm = csvUploadForm;
-    this.fileInput = csvUploadForm.querySelector(SELECTORS.fileInput)
+    this.fileInput = csvUploadForm.querySelector(SELECTORS.fileInput);
 
     this._setup();
   }
@@ -17,11 +17,11 @@ class CSVUploadForm {
   }
 
   _registerOnFileChangeEvent() {
-    document.addEventListener('DOMContentLoaded', () => {
-      // Csv File upload form - submit when file selected
-      this.fileInput.onchange = () => {
-        this.csvUploadForm.submit();
-      };
-    });
+    // Submit form when a file is selected
+    this.fileInput.onchange = () => {
+      this.csvUploadForm.submit();
+    };
   }
 }
+
+export default CSVUploadForm;

--- a/app/javascript/components/CSVUploadForm/index.js
+++ b/app/javascript/components/CSVUploadForm/index.js
@@ -1,11 +1,11 @@
 const SELECTORS = {
-  fileInput: '#csv_upload_form_file'
+  fileInput: '.form-csv-upload__input-file'
 };
 
 class CSVUploadForm {
-  constructor(csvUploadForm) {
-    this.csvUploadForm = csvUploadForm;
-    this.fileInput = csvUploadForm.querySelector(SELECTORS.fileInput);
+  constructor(elementRef) {
+    this.csvUploadForm = elementRef;
+    this.fileInput = elementRef.querySelector(SELECTORS.fileInput);
 
     this._setup();
   }

--- a/app/javascript/components/csv_upload_form.js
+++ b/app/javascript/components/csv_upload_form.js
@@ -1,0 +1,27 @@
+const SELECTORS = {
+  fileInput: '#csv_upload_form_file'
+};
+
+class CSVUploadForm {
+  constructor(csvUploadForm) {
+    this.csvUploadForm = csvUploadForm;
+    this.fileInput = csvUploadForm.querySelector(SELECTORS.fileInput)
+
+    this._setup();
+  }
+
+  // private
+
+  _setup() {
+    this._registerOnFileChangeEvent();
+  }
+
+  _registerOnFileChangeEvent() {
+    document.addEventListener('DOMContentLoaded', () => {
+      // Csv File upload form - submit when file selected
+      this.fileInput.onchange = () => {
+        this.csvUploadForm.submit();
+      };
+    });
+  }
+}

--- a/app/javascript/screens/index.js
+++ b/app/javascript/screens/index.js
@@ -1,0 +1,1 @@
+import './keywords';

--- a/app/javascript/screens/index.js
+++ b/app/javascript/screens/index.js
@@ -1,6 +1,6 @@
-document.addEventListener("DOMContentLoaded", (event) => {
+document.addEventListener('DOMContentLoaded', (event) => {
   // Csv File upload form - submit when file selected
-  document.getElementById('csv_upload_form_').onchange = () => {
-    document.getElementById('new_CSVUploadForm').submit()
-  }
+  document.getElementById('csv_upload_form_file').onchange = () => {
+    document.getElementById('new_CSVUploadForm').submit();
+  };
 });

--- a/app/javascript/screens/index.js
+++ b/app/javascript/screens/index.js
@@ -1,6 +1,0 @@
-document.addEventListener('DOMContentLoaded', (event) => {
-  // Csv File upload form - submit when file selected
-  document.getElementById('csv_upload_form_file').onchange = () => {
-    document.getElementById('new_CSVUploadForm').submit();
-  };
-});

--- a/app/javascript/screens/index.js
+++ b/app/javascript/screens/index.js
@@ -1,0 +1,6 @@
+document.addEventListener("DOMContentLoaded", (event) => {
+  // Csv File upload form - submit when file selected
+  document.getElementById('csv_upload_form_').onchange = () => {
+    document.getElementById('new_CSVUploadForm').submit()
+  }
+});

--- a/app/javascript/screens/keywords/index.js
+++ b/app/javascript/screens/keywords/index.js
@@ -1,0 +1,19 @@
+import CSVUploadForm from 'Components/CSVUploadForm';
+
+const SELECTORS = {
+  csvUploadForm: '#new_CSVUploadForm'
+};
+
+class KeywordsScreen {
+  constructor() {
+    this.csvUploadForm = document.querySelector(SELECTORS.csvUploadForm);
+
+    this._setup();
+  }
+
+  // private
+
+  _setup() {
+    new CSVUploadForm(this.csvUploadForm);
+  }
+}

--- a/app/javascript/screens/keywords/index.js
+++ b/app/javascript/screens/keywords/index.js
@@ -1,11 +1,11 @@
 import CSVUploadForm from '../../components/CSVUploadForm';
 
 const SELECTORS = {
-  screen: '#screen_keywords',
-  csvUploadForm: '#new_CSVUploadForm'
+  screen: '.screen-keyword',
+  csvUploadForm: '.form-csv-upload'
 };
 
-class KeywordsScreen {
+class KeywordScreen {
   constructor() {
     this.csvUploadForm = document.querySelector(SELECTORS.csvUploadForm);
 
@@ -20,9 +20,9 @@ class KeywordsScreen {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const isKeywordsScreen = document.querySelector(SELECTORS.screen) !== null;
+  const isKeywordScreen = document.querySelector(SELECTORS.screen) !== null;
 
-  if (isKeywordsScreen) {
-    new KeywordsScreen();
+  if (isKeywordScreen) {
+    new KeywordScreen();
   }
 });

--- a/app/javascript/screens/keywords/index.js
+++ b/app/javascript/screens/keywords/index.js
@@ -1,6 +1,7 @@
-import CSVUploadForm from 'Components/CSVUploadForm';
+import CSVUploadForm from '../../components/CSVUploadForm';
 
 const SELECTORS = {
+  screen: '#screen_keywords',
   csvUploadForm: '#new_CSVUploadForm'
 };
 
@@ -17,3 +18,11 @@ class KeywordsScreen {
     new CSVUploadForm(this.csvUploadForm);
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const isKeywordsScreen = document.querySelector(SELECTORS.screen) !== null;
+
+  if (isKeywordsScreen) {
+    new KeywordsScreen();
+  }
+});

--- a/app/views/keywords/_form_upload.html.erb
+++ b/app/views/keywords/_form_upload.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12 col-lg-4 col-md-6">
       <div class="custom-file">
         <%= f.label :file, t('csv.upload_btn'), class: 'custom-file-label' %>
-        <%= f.file_field :file, required: true, class: 'form-control custom-file-input' %>
+        <%= f.file_field :file, required: true, class: 'form-control custom-file-input form-csv-upload__input-file' %>
       </div>
     </div>
   </div>

--- a/app/views/keywords/_form_upload.html.erb
+++ b/app/views/keywords/_form_upload.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12 col-lg-4 col-md-6">
       <div class="custom-file">
         <%= f.label :file, t('csv.upload_btn'), class: 'custom-file-label' %>
-        <%= f.file_field :file, autofocus: true, class: 'form-control custom-file-input' %>
+        <%= f.file_field :file, class: 'form-control custom-file-input' %>
       </div>
     </div>
   </div>

--- a/app/views/keywords/_form_upload.html.erb
+++ b/app/views/keywords/_form_upload.html.erb
@@ -1,9 +1,9 @@
-<%= form_for(csv_form, as: CSVUploadForm, url: keywords_path, html: { method: :post, multipart: true }) do |f| %>
+<%= form_for(csv_form, as: CSVUploadForm, url: keywords_path, html: { method: :post, multipart: true, class:'form-csv-upload' }) do |f| %>
   <div class="row mb-3">
     <div class="col-12 col-lg-4 col-md-6">
       <div class="custom-file">
-        <%= f.label 'Upload a CSV File', class: 'custom-file-label' %>
-        <%= f.file_field csv_form.file, autofocus: true, class: 'form-control custom-file-input' %>
+        <%= f.label :file, t('csv.upload_btn'), class: 'custom-file-label' %>
+        <%= f.file_field :file, autofocus: true, class: 'form-control custom-file-input' %>
       </div>
     </div>
   </div>

--- a/app/views/keywords/_form_upload.html.erb
+++ b/app/views/keywords/_form_upload.html.erb
@@ -1,0 +1,10 @@
+<%= form_for(csv_form, as: CSVUploadForm, url: keywords_path, html: { method: :post, multipart: true }) do |f| %>
+  <div class="row mb-3">
+    <div class="col-12 col-lg-4 col-md-6">
+      <div class="custom-file">
+        <%= f.label 'Upload a CSV File', class: 'custom-file-label' %>
+        <%= f.file_field csv_form.file, autofocus: true, class: 'form-control custom-file-input' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/keywords/_form_upload.html.erb
+++ b/app/views/keywords/_form_upload.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12 col-lg-4 col-md-6">
       <div class="custom-file">
         <%= f.label :file, t('csv.upload_btn'), class: 'custom-file-label' %>
-        <%= f.file_field :file, class: 'form-control custom-file-input' %>
+        <%= f.file_field :file, required: true, class: 'form-control custom-file-input' %>
       </div>
     </div>
   </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,3 +1,4 @@
 <div class="container">
+  <%= render 'form_upload', csv_form: csv_form %>
   <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
 </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container" id="screen_keywords">
+<div class="container screen-keyword">
   <%= render 'form_upload', csv_form: csv_form %>
   <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
 </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" id="screen_keywords">
   <%= render 'form_upload', csv_form: csv_form %>
   <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,16 +13,7 @@
 <div class="d-flex flex-column sticky-footer-wrapper min-vh-100">
   <%= render 'shared/header' %>
   <main class="flex-fill">
-    <div class="container mt-2">
-      <div class="row justify-content-center">
-        <% if notice %>
-          <p class="alert alert-info"><%= notice %></p>
-        <% end %>
-        <% if alert %>
-          <p class="alert alert-warning"><%= alert %></p>
-        <% end %>
-      </div>
-    </div>
+    <%= render 'shared/alert' %>
     <%= yield %>
   </main>
   <%= render 'shared/footer' %>

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,0 +1,20 @@
+<div class="container mt-2">
+  <div class="row justify-content-center">
+    <% if notice %>
+      <p class="alert alert-info"><%= notice %></p>
+    <% end %>
+    <% if alert %>
+      <p class="alert alert-warning"><%= alert %></p>
+    <% end %>
+    <% if flash[:errors] %>
+      <div class="alert alert-danger">
+        <% flash[:errors].each do |error| %>
+          <p class="mb-0"><%= error %></p>
+        <% end %>
+      </div>
+    <% end %>
+    <% if flash[:success] %>
+      <p class="alert alert-success"><%= flash[:success] %></p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     btn_reset_password : 'Send me reset password instructions'
   csv:
     upload_success: 'Your file has been uploaded!'
+    upload_btn: 'Upload a CSV File'
     validation:
       wrong_count: 'The csv file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is csv'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,9 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { registrations: :registrations }
 
-  resources :keywords, only: :index
+  resources :keywords, only: [:index, :create]
 
-  resources :users, only: %i[create]
+  resources :users, only: :create
 
   namespace :api do
     namespace :v1 do

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CSVUploadForm, type: :form do
     end
 
     context 'given a too long keyword' do
-      it 'returns 1 keyword errors' do
+      it 'returns a bad_keyword_length error' do
         form, = save_csv_file 'invalid_keywords.csv'
 
         expect(form.errors.full_messages.to_s).to include(I18n.t('csv.validation.bad_keyword_length'))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,4 +29,5 @@ RSpec.configure do |config|
   config.include DeviseHelpers::SystemHelpers
 
   config.include FileUploadHelpers::Form
+  config.include FileUploadHelpers::System
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  # Run authentication when needed
+  config.before(:all, authenticated_user: true) do
+    sign_in Fabricate(:user)
+  end
+
   config.mock_with :rspec do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -21,8 +21,6 @@ module FileUploadHelpers
 
   module System
     def submit_file(name)
-      sign_in Fabricate(:user)
-
       visit root_path
 
       page.attach_file('csv_upload_form_file', Rails.root.join('spec', 'fixtures', 'files', 'csv', name), visible: :all)

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -14,7 +14,8 @@ module FileUploadHelpers
       file = file_fixture("csv/#{file_name}")
 
       type = MIME::Types.type_for(file.extname).first.content_type
-
+      Rails.logger.debug type
+      Rails.logger.debug file
       ActionDispatch::Http::UploadedFile.new({ tempfile: file, type: type })
     end
   end
@@ -23,9 +24,11 @@ module FileUploadHelpers
     def submit_file(name)
       sign_in Fabricate(:user)
 
-      page.attach_file(I18n.t('csv.upload_btn'), Rails.root.join('spec', 'fixtures', 'files', 'csv', name))
+      visit root_path
 
-      click I18n.t('csv.submit_btn')
+      page.attach_file('csv_upload_form_file', Rails.root.join('spec', 'fixtures', 'files', 'csv', name), visible: :all)
+
+      # page.execute_script('document.getElementById("new_CSVUploadForm").submit()')
     end
   end
 end

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -14,8 +14,7 @@ module FileUploadHelpers
       file = file_fixture("csv/#{file_name}")
 
       type = MIME::Types.type_for(file.extname).first.content_type
-      Rails.logger.debug type
-      Rails.logger.debug file
+
       ActionDispatch::Http::UploadedFile.new({ tempfile: file, type: type })
     end
   end

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -18,4 +18,14 @@ module FileUploadHelpers
       ActionDispatch::Http::UploadedFile.new({ tempfile: file, type: type })
     end
   end
+
+  module System
+    def submit_file(name)
+      sign_in Fabricate(:user)
+
+      page.attach_file(I18n.t('csv.upload_btn'), Rails.root.join('spec', 'fixtures', 'files', 'csv', name))
+
+      click I18n.t('csv.submit_btn')
+    end
+  end
 end

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -26,8 +26,6 @@ module FileUploadHelpers
       visit root_path
 
       page.attach_file('csv_upload_form_file', Rails.root.join('spec', 'fixtures', 'files', 'csv', name), visible: :all)
-
-      # page.execute_script('document.getElementById("new_CSVUploadForm").submit()')
     end
   end
 end

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -5,9 +5,7 @@ require 'rails_helper'
 describe 'csv upload form', type: :system do
   describe 'keywords#index' do
     context 'when user reach the home page' do
-      it 'displays the file upload form' do
-        sign_in Fabricate(:user)
-
+      it 'displays the file upload form', authenticated_user: true do
         visit root_path
 
         expect(find('form.form-csv-upload')).to have_field('csv_upload_form_file', visible: :all)
@@ -17,13 +15,13 @@ describe 'csv upload form', type: :system do
 
   describe 'keywords#create' do
     context 'given a valid csv file' do
-      it 'redirects to the homepage' do
+      it 'redirects to the homepage', authenticated_user: true  do
         submit_file 'valid.csv'
 
         expect(page).to have_current_path(keywords_path)
       end
 
-      it 'displays an upload success message' do
+      it 'displays an upload success message', authenticated_user: true  do
         submit_file 'valid.csv'
 
         expect(find('.alert.alert-success')).to have_content(I18n.t('csv.upload_success'))
@@ -31,7 +29,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a text file' do
-      it 'displays the wrong_type error' do
+      it 'displays the wrong_type error', authenticated_user: true  do
         submit_file 'wrong_type.txt'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_type'))
@@ -39,7 +37,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a file with too many keywords' do
-      it 'displays the wrong_count error' do
+      it 'displays the wrong_count error', authenticated_user: true  do
         submit_file 'too_many_keywords.csv'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_count'))
@@ -47,7 +45,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a file with a too long keyword' do
-      it 'displays the bad_keyword_length error' do
+      it 'displays the bad_keyword_length error', authenticated_user: true  do
         submit_file 'invalid_keywords.csv'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.bad_keyword_length'))

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -15,13 +15,13 @@ describe 'csv upload form', type: :system do
 
   describe 'keywords#create' do
     context 'given a valid csv file' do
-      it 'redirects to the homepage', authenticated_user: true  do
+      it 'redirects to the homepage', authenticated_user: true do
         submit_file 'valid.csv'
 
         expect(page).to have_current_path(keywords_path)
       end
 
-      it 'displays an upload success message', authenticated_user: true  do
+      it 'displays an upload success message', authenticated_user: true do
         submit_file 'valid.csv'
 
         expect(find('.alert.alert-success')).to have_content(I18n.t('csv.upload_success'))
@@ -29,7 +29,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a text file' do
-      it 'displays the wrong_type error', authenticated_user: true  do
+      it 'displays the wrong_type error', authenticated_user: true do
         submit_file 'wrong_type.txt'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_type'))
@@ -37,7 +37,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a file with too many keywords' do
-      it 'displays the wrong_count error', authenticated_user: true  do
+      it 'displays the wrong_count error', authenticated_user: true do
         submit_file 'too_many_keywords.csv'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_count'))
@@ -45,7 +45,7 @@ describe 'csv upload form', type: :system do
     end
 
     context 'given a file with a too long keyword' do
-      it 'displays the bad_keyword_length error', authenticated_user: true  do
+      it 'displays the bad_keyword_length error', authenticated_user: true do
         submit_file 'invalid_keywords.csv'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.bad_keyword_length'))

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'csv upload form', type: :system do
+  describe 'keywords#index' do
+    context 'when user reach the home page' do
+      it 'displays the file upload form' do
+        sign_in Fabricate(:user)
+
+        expect(find('form.form-csv-upload')).to have_field(:file)
+      end
+    end
+  end
+
+  describe 'keywords#create' do
+    context 'given a valid csv file' do
+      it 'redirects to the homepage' do
+        submit_file 'valid.csv'
+
+        expect(page).to have_current_path(root_path)
+      end
+
+      it 'displays an upload success message' do
+        submit_file 'valid.csv'
+
+        expect(find('.alert.alert-success')).to have_content(I18n.t('csv.upload_success'))
+      end
+    end
+
+    context 'given a blank csv file' do
+      it 'displays the blank error' do
+        submit_file 'blank.csv'
+
+        expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.blank'))
+      end
+    end
+
+    context 'given a text file' do
+      it 'displays the wrong_type error' do
+        submit_file 'wrong_type.txt'
+
+        expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_type'))
+      end
+    end
+
+    context 'given a file with too many keywords' do
+      it 'displays the wrong_count error' do
+        submit_file 'too_many_keywords.txt'
+
+        expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_count'))
+      end
+    end
+
+    context 'given a file with invalid keywords' do
+      it 'displays some keyword errors' do
+        submit_file 'invalid_keywords.csv'
+
+        expect(find('.alert.alert-danger')).to have_content('keyword')
+      end
+    end
+  end
+end

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -46,11 +46,11 @@ describe 'csv upload form', type: :system do
       end
     end
 
-    context 'given a file with invalid keywords' do
-      it 'displays some keyword errors' do
+    context 'given a file with a too long keyword' do
+      it 'displays the bad_keyword_length error' do
         submit_file 'invalid_keywords.csv'
 
-        expect(find('.alert.alert-danger')).to have_content('Keyword')
+        expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.bad_keyword_length'))
       end
     end
   end

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -8,7 +8,9 @@ describe 'csv upload form', type: :system do
       it 'displays the file upload form' do
         sign_in Fabricate(:user)
 
-        expect(find('form.form-csv-upload')).to have_field(:file)
+        visit root_path
+
+        expect(find('form.form-csv-upload')).to have_field('csv_upload_form_file', visible: :all)
       end
     end
   end
@@ -18,21 +20,13 @@ describe 'csv upload form', type: :system do
       it 'redirects to the homepage' do
         submit_file 'valid.csv'
 
-        expect(page).to have_current_path(root_path)
+        expect(page).to have_current_path(keywords_path)
       end
 
       it 'displays an upload success message' do
         submit_file 'valid.csv'
 
         expect(find('.alert.alert-success')).to have_content(I18n.t('csv.upload_success'))
-      end
-    end
-
-    context 'given a blank csv file' do
-      it 'displays the blank error' do
-        submit_file 'blank.csv'
-
-        expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.blank'))
       end
     end
 
@@ -46,7 +40,7 @@ describe 'csv upload form', type: :system do
 
     context 'given a file with too many keywords' do
       it 'displays the wrong_count error' do
-        submit_file 'too_many_keywords.txt'
+        submit_file 'too_many_keywords.csv'
 
         expect(find('.alert.alert-danger')).to have_content(I18n.t('csv.validation.wrong_count'))
       end
@@ -56,7 +50,7 @@ describe 'csv upload form', type: :system do
       it 'displays some keyword errors' do
         submit_file 'invalid_keywords.csv'
 
-        expect(find('.alert.alert-danger')).to have_content('keyword')
+        expect(find('.alert.alert-danger')).to have_content('Keyword')
       end
     end
   end

--- a/spec/systems/csv_upload_form_spec.rb
+++ b/spec/systems/csv_upload_form_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe 'csv upload form', type: :system do
+describe 'CSV Upload Form', type: :system do
   describe 'keywords#index' do
-    context 'when user reach the home page' do
+    context 'when user reaches the homepage' do
       it 'displays the file upload form', authenticated_user: true do
         visit root_path
 
@@ -14,14 +14,14 @@ describe 'csv upload form', type: :system do
   end
 
   describe 'keywords#create' do
-    context 'given a valid csv file' do
+    context 'given a valid CSV file' do
       it 'redirects to the homepage', authenticated_user: true do
         submit_file 'valid.csv'
 
         expect(page).to have_current_path(keywords_path)
       end
 
-      it 'displays an upload success message', authenticated_user: true do
+      it 'displays the upload_success message', authenticated_user: true do
         submit_file 'valid.csv'
 
         expect(find('.alert.alert-success')).to have_content(I18n.t('csv.upload_success'))

--- a/spec/systems/keywords_list_spec.rb
+++ b/spec/systems/keywords_list_spec.rb
@@ -4,19 +4,19 @@ require 'rails_helper'
 
 describe 'keywords list', type: :system do
   context 'given no keywords' do
-    it 'shows the empty_list message', authenticated_user: true  do
+    it 'shows the empty_list message', authenticated_user: true do
       visit root_path
 
       expect(find('.list-keyword')).to have_content(I18n.t('keywords.empty_list'))
     end
 
-    it 'does not show the pagination nav', authenticated_user: true  do
+    it 'does not show the pagination nav', authenticated_user: true do
       visit root_path
 
       expect(find('.list-keyword')).not_to have_selector('.pagination')
     end
 
-    it 'does not show any keyword', authenticated_user: true  do
+    it 'does not show any keyword', authenticated_user: true do
       visit root_path
 
       expect(find('.list-keyword')).not_to have_selector('.list-keyword-item')

--- a/spec/systems/keywords_list_spec.rb
+++ b/spec/systems/keywords_list_spec.rb
@@ -4,25 +4,19 @@ require 'rails_helper'
 
 describe 'keywords list', type: :system do
   context 'given no keywords' do
-    it 'shows the empty_list message' do
-      sign_in Fabricate(:user)
-
+    it 'shows the empty_list message', authenticated_user: true  do
       visit root_path
 
       expect(find('.list-keyword')).to have_content(I18n.t('keywords.empty_list'))
     end
 
-    it 'does not show the pagination nav' do
-      sign_in Fabricate(:user)
-
+    it 'does not show the pagination nav', authenticated_user: true  do
       visit root_path
 
       expect(find('.list-keyword')).not_to have_selector('.pagination')
     end
 
-    it 'does not show any keyword' do
-      sign_in Fabricate(:user)
-
+    it 'does not show any keyword', authenticated_user: true  do
       visit root_path
 
       expect(find('.list-keyword')).not_to have_selector('.list-keyword-item')

--- a/spec/systems/signup_spec.rb
+++ b/spec/systems/signup_spec.rb
@@ -58,8 +58,7 @@ describe 'signup', type: :system do
   end
 
   context 'when an authenticated user reaches the sign up page' do
-    it 'redirects him to the root_page' do
-      sign_in(Fabricate(:user))
+    it 'redirects him to the root_page', authenticated_user: true  do
       visit new_user_registration_path
 
       expect(page).to have_current_path(root_path)

--- a/spec/systems/signup_spec.rb
+++ b/spec/systems/signup_spec.rb
@@ -58,7 +58,7 @@ describe 'signup', type: :system do
   end
 
   context 'when an authenticated user reaches the sign up page' do
-    it 'redirects him to the root_page', authenticated_user: true  do
+    it 'redirects him to the root_page', authenticated_user: true do
       visit new_user_registration_path
 
       expect(page).to have_current_path(root_path)


### PR DESCRIPTION
- #13 

## What happened

- Add UI for uploading CSV Files.
- Displays error or success message.

## Insight

- Add UI for uploading CSV Files.
    - basic form, no submit button (submit is triggered by JavaScript `javascript/screen/index.js` when a file is selected)
    - POST method `keywords#create`. Will redirect to index by adding a flash error/success based on CSV parsing/validation status (from backend)
- Displays error or success message.
    - `errors` flash message added (as a string array)
    - `success` flash message added (as a string)

## Proof Of Work

Form on home page:
![image](https://user-images.githubusercontent.com/77609814/124411458-c40d0880-dd76-11eb-946c-728b9d4aa74b.png)

Error message:
![image](https://user-images.githubusercontent.com/77609814/124411484-d25b2480-dd76-11eb-92f1-a58fef55758d.png)

Success message (with loading if just-uploaded keywords):
![image](https://user-images.githubusercontent.com/77609814/124411560-f61e6a80-dd76-11eb-81d5-9814ec2f1ed2.png)

System tests covering all use-cases.
![image](https://user-images.githubusercontent.com/77609814/124411971-bb690200-dd77-11eb-9bb6-065168b59ce8.png)
