### PR TITLE
[#19] [API] As a User, I can upload a csv file in order to run multiple keyword searches

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -14,7 +14,7 @@ module API
 
       def create
         if csv_form.save(create_params[:file])
-          render json: success_create
+          render json: create_success_response
 
         else
           render_errors(
@@ -39,7 +39,7 @@ module API
         params.permit(:file)
       end
 
-      def success_create
+      def create_success_response
         {
           meta: I18n.t('csv.upload_success')
         }

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -15,6 +15,7 @@ module API
       def create
         if csv_form.save(create_params[:file])
           render json: success_create
+
         else
           render_errors(
             details: csv_form.errors.full_messages,

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -15,7 +15,6 @@ module API
       def create
         if csv_form.save(create_params[:file])
           render json: create_success_response
-
         else
           render_errors(
             details: csv_form.errors.full_messages,

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -16,7 +16,11 @@ module API
         if csv_form.save(create_params[:file])
           render json: success_create
         else
-          render json: build_error(detail: csv_form.errors.full_messages, code: :invalid_file)
+          render_errors(
+            details: csv_form.errors.full_messages,
+            code: :invalid_file,
+            status: :unprocessable_entity
+          )
         end
       end
 

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -12,10 +12,32 @@ module API
         render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
       end
 
+      def create
+        if csv_form.save(create_params[:file])
+          render json: success_create
+        else
+          render json: build_error(detail: csv_form.errors.full_messages, code: :invalid_file)
+        end
+      end
+
       private
 
       def keywords
         KeywordsQuery.new(current_user).call
+      end
+
+      def csv_form
+        @csv_form ||= CSVUploadForm.new(current_user)
+      end
+
+      def create_params
+        params.permit(:file)
+      end
+
+      def success_create
+        {
+          meta: I18n.t('csv.upload_success')
+        }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       # User sign_up
       resources :users, only: :create
-      resources :keywords, only: :index
+
+      resources :keywords, only: [:index, :create]
 
       # OAuth2 (token, revoke, ...)
       use_doorkeeper do

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -83,4 +83,58 @@ describe API::V1::KeywordsController, type: :request do
       end
     end
   end
+
+  describe 'POST #create' do
+    context 'given an invalid file' do
+      it 'does not save any new keyword' do
+        create_token_header
+
+        params = file_params 'too_many_keywords.csv'
+
+        expect { post :create, params: params }.to change(Keyword, :count).by(0)
+      end
+
+      it 'returns an errors object' do
+        create_token_header
+
+        post :create, params: file_params('too_many_keywords.csv')
+
+        expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
+      end
+
+      it 'respond with a 422 Unprocessable Entity status code' do
+        create_token_header
+
+        post :create, params: file_params('too_many_keywords.csv')
+
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context 'given a valid file' do
+      it 'saves the keywords in the DB' do
+        create_token_header
+
+        params = file_params 'valid.csv'
+
+        expect { post :create, params: params }.to change(Keyword, :count).by(8)
+      end
+
+      it 'returns a success meta message' do
+        create_token_header
+
+        post :create, params: file_params('valid.csv')
+
+        expect(JSON.parse(response.body)['meta']).to eq(I18n.t('csv.upload_success'))
+      end
+
+      it 'responds with a 200 OK status code' do
+        create_token_header
+
+        post :create, params: file_params('valid.csv')
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -102,7 +102,7 @@ describe API::V1::KeywordsController, type: :request do
         expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
       end
 
-      it 'respond with a 422 Unprocessable Entity status code' do
+      it 'respondS with a 422 Unprocessable Entity status code' do
         create_token_header
 
         post :create, params: file_params('too_many_keywords.csv')

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -83,26 +83,6 @@ describe API::V1::KeywordsController, type: :request do
   end
 
   describe 'POST #create' do
-    context 'given an invalid file' do
-      it 'does not save any new keyword', authenticated_api_user: true do
-        params = file_params 'too_many_keywords.csv'
-
-        expect { post :create, params: params }.to change(Keyword, :count).by(0)
-      end
-
-      it 'returns an errors object', authenticated_api_user: true do
-        post :create, params: file_params('too_many_keywords.csv')
-
-        expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
-      end
-
-      it 'responds with a 422 Unprocessable Entity status code', authenticated_api_user: true do
-        post :create, params: file_params('too_many_keywords.csv')
-
-        expect(response.status).to eq(422)
-      end
-    end
-
     context 'given a valid file' do
       it 'saves the keywords in the DB', authenticated_api_user: true do
         params = file_params 'valid.csv'
@@ -120,6 +100,26 @@ describe API::V1::KeywordsController, type: :request do
         post :create, params: file_params('valid.csv')
 
         expect(response.status).to eq(200)
+      end
+    end
+
+    context 'given an invalid file' do
+      it 'does not save any new keyword', authenticated_api_user: true do
+        params = file_params 'too_many_keywords.csv'
+
+        expect { post :create, params: params }.to change(Keyword, :count).by(0)
+      end
+
+      it 'returns an errors object', authenticated_api_user: true do
+        post :create, params: file_params('too_many_keywords.csv')
+
+        expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
+      end
+
+      it 'responds with a 422 Unprocessable Entity status code', authenticated_api_user: true do
+        post :create, params: file_params('too_many_keywords.csv')
+
+        expect(response.status).to eq(422)
       end
     end
   end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -13,9 +13,7 @@ describe API::V1::KeywordsController, type: :request do
     end
 
     context 'when keyword_list is empty' do
-      it 'returns an empty data array' do
-        create_token_header(Fabricate(:user))
-
+      it 'returns an empty data array', authenticated_api_user: true do
         get :index
 
         expect(JSON.parse(response.body)['data'].count).to eq(0)
@@ -34,7 +32,7 @@ describe API::V1::KeywordsController, type: :request do
         expect(JSON.parse(response.body)['data'].count).to eq(50)
       end
 
-      it 'returns the total pages meta info' do
+      it 'returns the total_pages meta info' do
         user = Fabricate(:user)
         Fabricate.times(51, :keyword, user: user)
 
@@ -86,25 +84,19 @@ describe API::V1::KeywordsController, type: :request do
 
   describe 'POST #create' do
     context 'given an invalid file' do
-      it 'does not save any new keyword' do
-        create_token_header
-
+      it 'does not save any new keyword', authenticated_api_user: true do
         params = file_params 'too_many_keywords.csv'
 
         expect { post :create, params: params }.to change(Keyword, :count).by(0)
       end
 
-      it 'returns an errors object' do
-        create_token_header
-
+      it 'returns an errors object', authenticated_api_user: true do
         post :create, params: file_params('too_many_keywords.csv')
 
         expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
       end
 
-      it 'responds with a 422 Unprocessable Entity status code' do
-        create_token_header
-
+      it 'responds with a 422 Unprocessable Entity status code', authenticated_api_user: true do
         post :create, params: file_params('too_many_keywords.csv')
 
         expect(response.status).to eq(422)
@@ -112,25 +104,19 @@ describe API::V1::KeywordsController, type: :request do
     end
 
     context 'given a valid file' do
-      it 'saves the keywords in the DB' do
-        create_token_header
-
+      it 'saves the keywords in the DB', authenticated_api_user: true do
         params = file_params 'valid.csv'
 
         expect { post :create, params: params }.to change(Keyword, :count).by(8)
       end
 
-      it 'returns a success meta message' do
-        create_token_header
-
+      it 'returns the upload_success meta message', authenticated_api_user: true do
         post :create, params: file_params('valid.csv')
 
         expect(JSON.parse(response.body)['meta']).to eq(I18n.t('csv.upload_success'))
       end
 
-      it 'responds with a 200 OK status code' do
-        create_token_header
-
+      it 'responds with a 200 OK status code', authenticated_api_user: true do
         post :create, params: file_params('valid.csv')
 
         expect(response.status).to eq(200)

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -102,7 +102,7 @@ describe API::V1::KeywordsController, type: :request do
         expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
       end
 
-      it 'respondS with a 422 Unprocessable Entity status code' do
+      it 'responds with a 422 Unprocessable Entity status code' do
         create_token_header
 
         post :create, params: file_params('too_many_keywords.csv')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ RSpec.configure do |config|
     sign_in Fabricate(:user)
   end
 
+  config.before(:each, authenticated_api_user: true) do
+    create_token_header
+  end
+
   config.mock_with :rspec do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -58,10 +58,18 @@ module OAuthHelpers
     }
   end
 
-  def create_token_header(user)
+  def create_token_header(user = nil)
+    user ||= Fabricate(:user)
+
     application = Fabricate(:application)
     access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
 
     request.headers['Authorization'] = "Bearer #{access_token.token}"
+  end
+
+  def file_params(file_name)
+    path = Rails.root.join('spec', 'fixtures', 'files', 'csv', file_name)
+
+    { file: Rack::Test::UploadedFile.new(path, 'text/csv', true) }
   end
 end


### PR DESCRIPTION
- #19 

## What happened

Add API endpoints to upload a CSV File and persist Keywords (if valid).

## Insight

Reusing the CSVUploadForm from backend PR. 
Simply adding a route, an action and handling 2 cases: success/error.

Tests cover a valid and an invalid file. 
> Note that I do not test again all types of errors as these ones are tested in the Forms/ spec already.

## Proof Of Work

- Request tests:
    ![image](https://user-images.githubusercontent.com/77609814/124718264-20675800-df30-11eb-86b0-89049719bafb.png)

- API responses (also available in the [API Documentation](https://documenter.getpostman.com/view/16135891/TzeTKqCb):
    - Success
    ```json
    {
            "meta": "Your file has been uploaded!"
    }
    ```
    - Errors
    ```json
    {
        "errors": {
            "details": [
                "The csv file should contain between 1 and 1000 keywords"
            ],
            "code": "invalid_file",
            "status": "unprocessable_entity"
        }
    }
    ```