### PR TITLE
#62 [Chore] Setup Turbo.hotwired.dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'doorkeeper' # Awesome OAuth 2 provider for your Rails / Grape app
 # Assets
 gem 'webpacker', '~>5.2.0' # Transpile app-like JavaScript
 gem 'sass-rails' # SASS
+gem 'turbo-rails' # Speed of SPA without any JavaScript
 
 # Logging tools
 gem 'colorize' # Ruby gem for colorizing text using ANSI escape sequences

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,6 +439,8 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     timecop (0.9.4)
+    turbo-rails (0.5.12)
+      rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     undercover (0.4.3)
@@ -535,6 +537,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (= 2.0.1)
   timecop
+  turbo-rails
   tzinfo-data
   undercover
   vcr

--- a/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
@@ -36,5 +36,5 @@
 //@import 'bootstrap/scss/tooltip';
 //@import 'bootstrap/scss/popover';
 //@import 'bootstrap/scss/carousel';
-//@import 'bootstrap/scss/spinners';
+@import 'bootstrap/scss/spinners';
 //@import 'bootstrap/scss/print';

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FiltersController < ApplicationController
+  def index
+    render locals: {
+      keywords_count: current_user.keywords.count
+    }
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,9 +4,10 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs';
-import '@hotwired/turbo-rails';
 import * as ActiveStorage from '@rails/activestorage';
 import 'channels';
+
+import '@hotwired/turbo-rails';
 
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs';
-import "@hotwired/turbo-rails"
+import '@hotwired/turbo-rails';
 import * as ActiveStorage from '@rails/activestorage';
 import 'channels';
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,6 +4,7 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs';
+import "@hotwired/turbo-rails"
 import * as ActiveStorage from '@rails/activestorage';
 import 'channels';
 

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag 'filters' do %>
+  <p>You have a total of <%= keywords_count %> keywords.</p>
+<% end %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,3 +1,3 @@
-<%= turbo_frame_tag 'filters' do %>
+<%= turbo_frame_tag 'frame_filters' do %>
   <p>You have a total of <%= keywords_count %> keywords.</p>
 <% end %>

--- a/app/views/keywords/_filters_keywords.html.erb
+++ b/app/views/keywords/_filters_keywords.html.erb
@@ -1,2 +1,2 @@
 <h5><%= t('filters') %></h5>
-<%= render 'filters_keywords_body', csv_form: csv_form %>
+<%= render 'filters_keywords_body' %>

--- a/app/views/keywords/_filters_keywords_body.html.erb
+++ b/app/views/keywords/_filters_keywords_body.html.erb
@@ -1,1 +1,7 @@
-<p>This is a filter!</p>
+<%= turbo_frame_tag 'filters', loading: "lazy", src: filters_path do %>
+  <div class="d-flex justify-content-center">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden"><%= t('loading') %>...</span>
+    </div>
+  </div>
+<% end %>

--- a/app/views/keywords/_filters_keywords_body.html.erb
+++ b/app/views/keywords/_filters_keywords_body.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag 'filters', loading: "lazy", src: filters_path do %>
+<%= turbo_frame_tag 'frame_filters', loading: "lazy", src: filters_path do %>
   <div class="d-flex justify-content-center">
     <div class="spinner-border text-primary" role="status">
       <span class="visually-hidden"><%= t('loading') %>...</span>

--- a/app/views/keywords/_filters_keywords_mobile.html.erb
+++ b/app/views/keywords/_filters_keywords_mobile.html.erb
@@ -4,6 +4,6 @@
     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body">
-    <%= render 'filters_keywords_body', csv_form: csv_form %>
+    <%= render 'filters_keywords_body' %>
   </div>
 </div>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,12 +1,14 @@
 <section class="list-keyword">
-  <% if keywords.groups.any? %>
-    <% keywords.groups.each do |group_key, group_keywords| %>
-      <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
+  <%= turbo_frame_tag 'list_keywords' do %>
+    <% if keywords.groups.any? %>
+      <% keywords.groups.each do |group_key, group_keywords| %>
+        <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
+      <% end %>
+      <div class="d-flex justify-content-around">
+        <%== pagy_bootstrap_nav(pagy) %>
+      </div>
+    <% else %>
+      <div class="alert alert-light"><%= t('keywords.empty_list') %></div>
     <% end %>
-    <div class="d-flex justify-content-around">
-      <%== pagy_bootstrap_nav(pagy) %>
-    </div>
-  <% else %>
-    <div class="alert alert-light"><%= t('keywords.empty_list') %></div>
   <% end %>
 </section>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,5 +1,5 @@
 <section class="list-keyword" data-turbo="true">
-  <%= turbo_frame_tag 'list_keywords' do %>
+  <%= turbo_frame_tag 'frame_list_keywords' do %>
     <% if keywords.groups.any? %>
       <% keywords.groups.each do |group_key, group_keywords| %>
         <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,4 +1,4 @@
-<section class="list-keyword">
+<section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'list_keywords' do %>
     <% if keywords.groups.any? %>
       <% keywords.groups.each do |group_key, group_keywords| %>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,7 +1,7 @@
-<div class="container screen-keyword">
+<div class="container-xl screen-keyword">
   <div class="row">
     <div class="col-md-4 col-lg-3 d-md-block d-none">
-      <%= render 'filters_keywords', csv_form: csv_form %>
+      <%= render 'filters_keywords' %>
     </div>
     <div class="col-md-8 col-lg-9">
       <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
@@ -9,7 +9,7 @@
   </div>
 </div>
 
-<%= render 'filters_keywords_mobile', csv_form: csv_form %>
+<%= render 'filters_keywords_mobile' %>
 
 <% content_for :header_nav_bar do %>
   <%= render 'form_upload', csv_form: csv_form %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="layout-default" lang='<%= I18n.locale %>'>
+<html class="layout-default" lang='<%= I18n.locale %>' data-turbo="false" >
 <head>
   <title><%= t('app_name') %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
         <div class="text-end">
           <%= yield :header_nav_bar %>
           <%= link_to t('my_profile'), edit_user_registration_path, class: 'btn btn-outline-light' %>
-          <%= button_to t('auth.logout'), destroy_user_session_path, data:{turbo: 'false'}, method: :delete, form_class: 'd-inline', class: 'btn btn-warning me-2' %>
+          <%= button_to t('auth.logout'), destroy_user_session_path, method: :delete, form_class: 'd-inline', class: 'btn btn-warning me-2' %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="p-3 bg-dark text-white">
-  <div class="container">
+  <div class="container-xl">
     <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
       <a href="/" class="d-flex align-items-center mb-2 mb-lg-0 text-white text-decoration-none">
         <%= image_tag 'logo.svg', class: 'bi me-2', width: 40, height: 40,

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,8 +18,8 @@
         </form>
         <div class="text-end">
           <%= yield :header_nav_bar %>
-          <%= link_to t('my_profile'), edit_user_registration_path, method: :get, class: 'btn btn-outline-light' %>
-          <%= link_to t('auth.logout'), destroy_user_session_path, method: :delete, class: 'btn btn-warning me-2' %>
+          <%= link_to t('my_profile'), edit_user_registration_path, class: 'btn btn-outline-light' %>
+          <%= button_to t('auth.logout'), destroy_user_session_path, data:{turbo: 'false'}, method: :delete, form_class: 'd-inline', class: 'btn btn-warning me-2' %>
         </div>
       <% end %>
     </div>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,5 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
+  adapter: async
 
 test:
   adapter: test

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,3 +62,4 @@ en:
   forgot_password: 'Forgot your password?'
   my_profile: 'My Profile'
   filters: 'Filters'
+  loading: 'Loading'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
   resources :keywords, only: [:index, :create]
 
+  resources :filters, only: :index
+
   resources :users, only: :create
 
   namespace :api do

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "7.13.0",
+    "@hotwired/turbo-rails": "7.0.0-beta.8",
     "@popperjs/core": "2.9.2",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,19 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@hotwired/turbo-rails@7.0.0-beta.8":
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.0-beta.8.tgz#609eccfdc636c40e34244333f0fe947e573b4b8f"
+  integrity sha512-Azs1UevWbGLCFfcf0ymz/uZlvQR3nuc/ymT4+XTMpsiAIVjq1Y3FJw5gseXpumzz+r3U6sLWIPa+c1Acd5Zofw==
+  dependencies:
+    "@hotwired/turbo" "^7.0.0-beta.8"
+    "@rails/actioncable" "^6.0.0"
+
+"@hotwired/turbo@^7.0.0-beta.8":
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.0-beta.8.tgz#133630eabbd3c26183efcfb6dea2db5dd172e8da"
+  integrity sha512-3HfWoxtGGQOxaXo2bh2tvEBFAV4oSSIA/BFnMvIfY5D4HbEKYpPH2Q3Roa707/E9LtnIgyN/RibDY6dszCwPuw==
+
 "@nimblehq/eslint-config-nimble@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@nimblehq/eslint-config-nimble/-/eslint-config-nimble-2.1.1.tgz#0a1ff8b37e826ff71569c79c333a203899f4b0e4"


### PR DESCRIPTION
- #62

## Issues encountered

- Bootstrap Native is not well supporting "adding element later", as [this post](https://github.com/thednp/bootstrap.native/wiki/FAQs#does-it-work-with-later-added-elements) indicates.
    Workaround: Instead of opening the offcanvas with `data-bs-toggle`, I add a 'click' event-listener (few lines of JavaScript are then needed) and handle the offcanvas opening with Bootstrap Native API.

- Turbo Frames do not handle History API automatically [yet]. There is [an open PR](https://github.com/hotwired/turbo/pull/167), but not sure if it will get merged in later versions or not.
    ⚠️ This is an important point that could be a reason to NOT use Turbo in a client project (as the team needs to chose between poor UX or adding more JavaScript -- which lose a main benefit from Turbo).

> As this project is for learning purpose, I assume it is OK to move forward with full awareness of these limitations. 

A more complete example is shown in this [POC Pull Request](https://github.com/malparty/google-search-ruby/pull/64) which won't be merged.

## What happened

- Install `turbo-rails` gem (using beta as IC project // I would use a stable version for client projects)
- Use Turbo-Frame for keywords list (**1)
- User Turbo-Frame for Filter canvas (**2)

| **1 | **2 | 
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/125015622-0a75a680-e09a-11eb-8c97-18b412a5ad5c.png) | ![image](https://user-images.githubusercontent.com/77609814/125015763-558fb980-e09a-11eb-9a99-61d246539de7.png) |

## Insight

- Use Turbo-Frame for keywords list
    - Load only the keyword list when navigating between pages
- User Turbo-Frame for Filter canvas
    - Load only the filters when visible to the user (big screen = once tag loaded // mobile = when user toggle the filter canvas)
    Reduce initial loading time if a user simply wants to upload a new file for example.

## Proof Of Work

The keyword list is loaded with the initial load.
When switching from 1 page to another, it will only query the partial view and reload the `#list_keywords` frame.
Filters are lazy loading, so they will be requested only when we display them. Again, only the needed views are loaded (from `filters#index` -- currently returning a simple keyword count for demo purpose).

![Turbo_demo](https://user-images.githubusercontent.com/77609814/124932932-ac12de80-e02d-11eb-9f6c-810559297224.gif)