### PR TITLE
[#18] [API] As a User, I can see a list of my previous keyword results

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -20,6 +20,10 @@ module API
         )
       end
 
+      rescue_from ::ActiveRecord::RecordNotFound do
+        render_error(I18n.t('record_not_found'), status: :not_found)
+      end
+
       private
 
       # helper method to access the current user from the token

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -9,7 +9,11 @@ module API
       def index
         pagy, keywords_list = pagy(keywords)
 
-        render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
+        render json: KeywordsSerializer.new(keywords_list, pagy_options(pagy))
+      end
+
+      def show
+        render json: KeywordSerializer.new(current_user.keywords.find(show_params[:id]))
       end
 
       def create
@@ -42,6 +46,10 @@ module API
         {
           meta: I18n.t('csv.upload_success')
         }
+      end
+
+      def show_params
+        params.permit(:id)
       end
     end
   end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -9,13 +9,13 @@ module API
       def index
         pagy, keywords_list = pagy(keywords)
 
-        render json: KeywordsSerializer.new(keywords_list, pagy_options(pagy))
+        render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
       end
 
       def show
         keyword = current_user.keywords.find show_params[:id]
 
-        render json: KeywordSerializer.new(keyword, include: [:result_links])
+        render json: KeywordSerializer.new(keyword, include: [:result_links], params: { show: true })
       end
 
       def create

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -13,7 +13,9 @@ module API
       end
 
       def show
-        render json: KeywordSerializer.new(current_user.keywords.find(show_params[:id]))
+        keyword = current_user.keywords.find show_params[:id]
+
+        render json: KeywordSerializer.new(keyword, include: [:result_links])
       end
 
       def create

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -3,5 +3,5 @@
 class KeywordSerializer
   include JSONAPI::Serializer
 
-  attributes :name, :created_at
+  attributes :name, :created_at, :status, :ads_top_count, :ads_page_count, :non_ads_result_count, :total_link_count
 end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class KeywordSerializer < KeywordsSerializer
-  attribute :html
+class KeywordSerializer
+  include JSONAPI::Serializer
 
-  has_many :result_links
+  attributes :name, :created_at, :status, :ads_top_count, :ads_page_count, :non_ads_result_count, :total_link_count
+
+  attribute :html, if: proc { |_, params| params[:show] }
+
+  has_many :result_links, if: proc { |_, params| params[:show] }
 end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class KeywordSerializer < KeywordsSerializer
-  attributes :html, :result_links
+  attribute :html
+
+  has_many :result_links
 end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-class KeywordSerializer
-  include JSONAPI::Serializer
-
-  attributes :name, :created_at, :status, :ads_top_count, :ads_page_count, :non_ads_result_count, :total_link_count
+class KeywordSerializer < KeywordsSerializer
+  attributes :html, :result_links
 end

--- a/app/serializers/keywords_serializer.rb
+++ b/app/serializers/keywords_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class KeywordsSerializer
+  include JSONAPI::Serializer
+
+  attributes :name, :created_at, :status, :ads_top_count, :ads_page_count, :non_ads_result_count, :total_link_count
+end

--- a/app/serializers/keywords_serializer.rb
+++ b/app/serializers/keywords_serializer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class KeywordsSerializer
-  include JSONAPI::Serializer
-
-  attributes :name, :created_at, :status, :ads_top_count, :ads_page_count, :non_ads_result_count, :total_link_count
-end

--- a/app/serializers/result_link_serializer.rb
+++ b/app/serializers/result_link_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ResultLinkSerializer
+  include JSONAPI::Serializer
+
+  attributes :link_type, :url, :created_at
+
+  belongs_to :keyword
+end

--- a/app/serializers/result_link_serializer.rb
+++ b/app/serializers/result_link_serializer.rb
@@ -3,7 +3,5 @@
 class ResultLinkSerializer
   include JSONAPI::Serializer
 
-  attributes :link_type, :url, :created_at
-
-  belongs_to :keyword
+  attributes :url, :link_type, :created_at
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,4 @@ en:
   my_profile: 'My Profile'
   filters: 'Filters'
   loading: 'Loading'
+  record_not_found: 'The requested resource could not be found.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       # User sign_up
       resources :users, only: :create
 
-      resources :keywords, only: [:index, :create]
+      resources :keywords, only: [:index, :create, :show]
 
       # OAuth2 (token, revoke, ...)
       use_doorkeeper do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,5 +16,5 @@ end
 if Rails.env.development?
   user = User.where(email: 'admin@nimblehq.co').first_or_create(Fabricate.attributes_for(:admin, email: 'admin@nimblehq.co'))
 
-  Fabricate.times(100, :keyword_with_result, user: user)
+  Fabricate.times(100, :keyword_parsed_with_links, user: user)
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,5 +16,5 @@ end
 if Rails.env.development?
   user = User.where(email: 'admin@nimblehq.co').first_or_create(Fabricate.attributes_for(:admin, email: 'admin@nimblehq.co'))
 
-  Fabricate.times(100, :keyword, user: user)
+  Fabricate.times(100, :keyword_with_result, user: user)
 end

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -4,3 +4,17 @@ Fabricator(:keyword) do
   name { FFaker::FreedomIpsum.word }
   user { Fabricate(:user) }
 end
+
+Fabricator(:keyword_with_result, from: :keyword) do
+  name { FFaker::FreedomIpsum.word }
+  user { Fabricate(:user) }
+
+  status :parsed
+
+  ads_top_count { FFaker.rand 6 }
+  ads_page_count { |attrs| attrs[:ads_top_count] + FFaker.rand(3) }
+  non_ads_result_count { |attrs| 15 + attrs[:ads_top_count] }
+  total_link_count { |attrs| FFaker.rand(30) + attrs[:non_ads_result_count] }
+
+  html { FFaker::HTMLIpsum.body }
+end

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -5,7 +5,7 @@ Fabricator(:keyword) do
   user { Fabricate(:user) }
 end
 
-Fabricator(:keyword_with_result, from: :keyword) do
+Fabricator(:keyword_parsed, from: :keyword) do
   status :parsed
 
   ads_top_count { FFaker.rand 6 }
@@ -14,6 +14,8 @@ Fabricator(:keyword_with_result, from: :keyword) do
   total_link_count { |attrs| FFaker.rand(30) + attrs[:non_ads_result_count] }
 
   html { FFaker::HTMLIpsum.body }
+end
 
+Fabricator(:keyword_parsed_with_links, from: :keyword_parsed) do
   result_links(count: FFaker.rand(10))
 end

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -6,9 +6,6 @@ Fabricator(:keyword) do
 end
 
 Fabricator(:keyword_with_result, from: :keyword) do
-  name { FFaker::FreedomIpsum.word }
-  user { Fabricate(:user) }
-
   status :parsed
 
   ads_top_count { FFaker.rand 6 }
@@ -17,4 +14,6 @@ Fabricator(:keyword_with_result, from: :keyword) do
   total_link_count { |attrs| FFaker.rand(30) + attrs[:non_ads_result_count] }
 
   html { FFaker::HTMLIpsum.body }
+
+  result_links(count: FFaker.rand(10))
 end

--- a/spec/fabricators/result_link_fabricator.rb
+++ b/spec/fabricators/result_link_fabricator.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Fabricator(:result_link) do
-  keyword { Fabricate(:keyword) }
   link_type { FFaker.rand 3 }
   url { FFaker::Internet.http_url }
+end
+
+Fabricator(:result_link_with_keyword, from: :result_link) do
+  keyword { Fabricate(:keyword) }
 end

--- a/spec/models/result_link_spec.rb
+++ b/spec/models/result_link_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe ResultLink, type: :model do
   describe 'link_types' do
     context 'given valid attributes to a non_ads result_link' do
       it 'adds a non_ads link' do
-        expect { Fabricate(:result_link, link_type: :non_ads) }.to change(described_class.non_ads, :count).by(1)
+        expect { Fabricate(:result_link_with_keyword, link_type: :non_ads) }.to change(described_class.non_ads, :count).by(1)
       end
 
       it 'does not change top_ad count' do
-        expect { Fabricate(:result_link, link_type: :non_ads) }.to change(described_class.ads_top, :count).by(0)
+        expect { Fabricate(:result_link_with_keyword, link_type: :non_ads) }.to change(described_class.ads_top, :count).by(0)
       end
 
       it 'returns a non-ad link' do
-        result_link = Fabricate(:result_link, link_type: :non_ads)
+        result_link = Fabricate(:result_link_with_keyword, link_type: :non_ads)
         expect(result_link).to be_non_ads
       end
     end
@@ -23,19 +23,19 @@ RSpec.describe ResultLink, type: :model do
   describe 'presence validations' do
     context 'given no link_type' do
       it 'raises a NotNullViolation error' do
-        expect { Fabricate(:result_link, link_type: nil) }.to raise_error(ActiveRecord::NotNullViolation)
+        expect { Fabricate(:result_link_with_keyword, link_type: nil) }.to raise_error(ActiveRecord::NotNullViolation)
       end
     end
 
     context 'given a blank url' do
       it 'raises a RecordInvalid error' do
-        expect { Fabricate(:result_link, url: '   ') }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { Fabricate(:result_link_with_keyword, url: '   ') }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
     context 'given no keyword' do
       it 'raises a RecordInvalid error' do
-        expect { Fabricate(:result_link, keyword: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { Fabricate(:result_link_with_keyword, keyword: nil) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -16,7 +16,42 @@ describe API::V1::KeywordsController, type: :request do
       it 'returns an empty data array', authenticated_api_user: true do
         get :index
 
-        expect(JSON.parse(response.body)['data'].count).to eq(0)
+        expect(json_response[:data].count).to eq(0)
+      end
+    end
+
+    context 'given one page of keywords' do
+      it 'returns the right number of keywords' do
+        user = Fabricate(:user)
+        Fabricate.times(15, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(json_response[:data].count).to eq(15)
+      end
+
+      it 'does not display the HTML attribute' do
+        user = Fabricate(:user)
+        Fabricate.times(15, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(json_response[:data].first[:attributes].keys).not_to include(:html)
+      end
+
+      it 'does not include any additional data such as the result_links' do
+        user = Fabricate(:user)
+        Fabricate.times(15, :keyword, user: user)
+
+        create_token_header(user)
+
+        get :index
+
+        expect(json_response[:included]).to be_nil
       end
     end
 
@@ -29,7 +64,7 @@ describe API::V1::KeywordsController, type: :request do
 
         get :index
 
-        expect(JSON.parse(response.body)['data'].count).to eq(50)
+        expect(json_response[:data].count).to eq(50)
       end
 
       it 'returns the total_pages meta info' do
@@ -40,7 +75,7 @@ describe API::V1::KeywordsController, type: :request do
 
         get :index
 
-        expect(JSON.parse(response.body)['meta']['total_pages']).to eq(2)
+        expect(json_response[:meta][:total_pages]).to eq(2)
       end
 
       it 'returns the links to related pages' do
@@ -51,7 +86,7 @@ describe API::V1::KeywordsController, type: :request do
 
         get :index
 
-        expect(JSON.parse(response.body)['links'].keys).to contain_exactly('self', 'first', 'prev', 'next', 'last')
+        expect(json_response[:links].keys).to contain_exactly(:self, :first, :prev, :next, :last)
       end
     end
 
@@ -64,7 +99,7 @@ describe API::V1::KeywordsController, type: :request do
 
         get :index, params: { page: 2 }
 
-        expect(JSON.parse(response.body)['data'].count).to eq(1)
+        expect(json_response[:data].count).to eq(1)
       end
     end
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -4,22 +4,6 @@ require 'rails_helper'
 
 describe API::V1::KeywordsController, type: :request do
   describe 'GET #index' do
-    context 'given an unauthenticated user' do
-      it 'returns a 401 status code' do
-        get :index
-
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context 'when keyword_list is empty' do
-      it 'returns an empty data array', authenticated_api_user: true do
-        get :index
-
-        expect(json_response[:data].count).to eq(0)
-      end
-    end
-
     context 'given one page of keywords' do
       it 'returns the right number of keywords' do
         user = Fabricate(:user)
@@ -113,6 +97,22 @@ describe API::V1::KeywordsController, type: :request do
         get :index, params: { page: 10 }
 
         expect(response.status).to eq(422)
+      end
+    end
+
+    context 'given an unauthenticated user' do
+      it 'returns a 401 status code' do
+        get :index
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when keyword_list is empty' do
+      it 'returns an empty data array', authenticated_api_user: true do
+        get :index
+
+        expect(json_response[:data].count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
- #18 

## What happened

Add API endpoints to expose keyword results data:
- Include ads/links counts in `keywords#index`
- Add `keywords#show` to expose html & links for a given keyword

## Insight

- Relationship with `result_link`:
    To reduce the needed requests, I decided to use the [included](https://jsonapi.org/format/#document-top-level) element to include `result_link` elements within `keywords/:id` queries.
- Fabricators: Some updates in here to enable to seed keywords **with** `result_links`. While keeping a way to fabricate `result_link` directly (which will Fabricate related Keywords/users) for testing the result_link model. 

## Proof Of Work

[/api/v1/keywords/408](https://documenter.getpostman.com/view/16135891/TzeTKqCb#cb4d8152-b222-499f-8df6-aa8d12250714)

```json
{
    "data": {
        "id": "410",
        "type": "keyword",
        "attributes": {
            "name": "Checkers",
            "created_at": "2021-07-09T06:55:14.356Z",
            "status": "parsed",
            "ads_top_count": 1,
            "ads_page_count": 1,
            "non_ads_result_count": 16,
            "total_link_count": 28,
            "html": "<h1>Laboriosam tempore</h1><p>Nisi [...]"
        },
        "relationships": {
            "result_links": {
                "data": [
                    {
                        "id": "826",
                        "type": "result_link"
                    },
                    [...]
                    {
                        "id": "830",
                        "type": "result_link"
                    }
                ]
            }
        }
    },
    "included": [
        {
            "id": "826",
            "type": "result_link",
            "attributes": {
                "url": "http://jerde.ca",
                "link_type": "ads_top",
                "created_at": "2021-07-09T06:55:14.365Z"
            }
        },
       [...]
        {
            "id": "830",
            "type": "result_link",
            "attributes": {
                "url": "http://dicki.com",
                "link_type": "non_ads",
                "created_at": "2021-07-09T06:55:14.386Z"
            }
        }
    ]
}
```
