### PR TITLE
#38 [Backend] As a user, my keywords are being parsed in background

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -14,7 +14,7 @@ class KeywordsController < ApplicationController
 
   def create
     if save_csv_file
-      Google::DistributeSearchJob.perform_later(csv_form.results)
+      Google::DistributeSearchJob.perform_later(csv_form.keyword_ids)
 
       flash[:success] = I18n.t('csv.upload_success')
     else

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -13,7 +13,9 @@ class KeywordsController < ApplicationController
   end
 
   def create
-    if csv_form.save(create_params[:csv_upload_form][:file])
+    if save_csv_file
+      Google::DistributeSearchJob.perform_later(csv_form.results)
+
       flash[:success] = I18n.t('csv.upload_success')
     else
       flash[:errors] = csv_form.errors.full_messages
@@ -30,6 +32,10 @@ class KeywordsController < ApplicationController
 
   def csv_form
     @csv_form ||= CSVUploadForm.new(current_user)
+  end
+
+  def save_csv_file
+    csv_form.save(create_params[:csv_upload_form][:file])
   end
 
   def create_params

--- a/app/forms/csv_upload_form.rb
+++ b/app/forms/csv_upload_form.rb
@@ -21,7 +21,7 @@ class CSVUploadForm
     begin
       Keyword.transaction do
         # rubocop:disable Rails/SkipsModelValidations
-        @keyword_ids = user.keywords.insert_all(parsed_keywords).map { |id| id['id'] }
+        @keyword_ids = user.keywords.insert_all(parsed_keywords).map { |keyword_hash| keyword_hash['id'] }
         # rubocop:enable Rails/SkipsModelValidations
       end
     rescue ActiveRecord::StatementInvalid

--- a/app/forms/csv_upload_form.rb
+++ b/app/forms/csv_upload_form.rb
@@ -5,7 +5,7 @@ require 'csv'
 class CSVUploadForm
   include ActiveModel::Validations
 
-  attr_reader :file, :results
+  attr_reader :file, :keyword_ids
 
   validates_with CSVValidator
 
@@ -21,7 +21,7 @@ class CSVUploadForm
     begin
       Keyword.transaction do
         # rubocop:disable Rails/SkipsModelValidations
-        @results = user.keywords.insert_all(parsed_keywords, returning: %w[id name]).to_a
+        @keyword_ids = user.keywords.insert_all(parsed_keywords).map { |id| id['id'] }
         # rubocop:enable Rails/SkipsModelValidations
       end
     rescue ActiveRecord::StatementInvalid

--- a/app/forms/csv_upload_form.rb
+++ b/app/forms/csv_upload_form.rb
@@ -5,7 +5,7 @@ require 'csv'
 class CSVUploadForm
   include ActiveModel::Validations
 
-  attr_reader :file
+  attr_reader :file, :results
 
   validates_with CSVValidator
 
@@ -21,7 +21,7 @@ class CSVUploadForm
     begin
       Keyword.transaction do
         # rubocop:disable Rails/SkipsModelValidations
-        user.keywords.insert_all parsed_keywords
+        @results = user.keywords.insert_all(parsed_keywords, returning: %w[id name]).to_a
         # rubocop:enable Rails/SkipsModelValidations
       end
     rescue ActiveRecord::StatementInvalid

--- a/app/jobs/google/distribute_search_job.rb
+++ b/app/jobs/google/distribute_search_job.rb
@@ -5,8 +5,8 @@ module Google
     queue_as :default
 
     def perform(keyword_ids)
-      keyword_ids.each do |keyword_id|
-        SearchKeywordJob.perform_later(keyword_id)
+      keyword_ids.each_with_index do |keyword_id, index|
+        SearchKeywordJob.set(wait: index * 3).perform_later(keyword_id)
       end
     end
   end

--- a/app/jobs/google/distribute_search_job.rb
+++ b/app/jobs/google/distribute_search_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Google
+  class DistributeSearchJob < ApplicationJob
+    queue_as :default
+
+    def perform(keywords)
+      keywords.each do |keyword|
+        SearchKeywordJob.perform_later(keyword)
+      end
+    end
+  end
+end

--- a/app/jobs/google/distribute_search_job.rb
+++ b/app/jobs/google/distribute_search_job.rb
@@ -4,9 +4,9 @@ module Google
   class DistributeSearchJob < ApplicationJob
     queue_as :default
 
-    def perform(keywords)
-      keywords.each do |keyword|
-        SearchKeywordJob.perform_later(keyword)
+    def perform(keyword_ids)
+      keyword_ids.each do |keyword_id|
+        SearchKeywordJob.perform_later(keyword_id)
       end
     end
   end

--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -6,7 +6,7 @@ module Google
   class SearchKeywordJob < ApplicationJob
     queue_as :default
 
-    retry_on ClientServiceError, ArgumentError
+    retry_on ClientServiceError, ArgumentError, wait: 12.seconds
 
     def perform(keyword_id)
       keyword = Keyword.where(id: keyword_id).select(:id, :name, :user_id).take

--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -6,8 +6,6 @@ module Google
   class SearchKeywordJob < ApplicationJob
     queue_as :default
 
-    retry_on ClientServiceError, ArgumentError, wait: 12.seconds
-
     def perform(keyword_id)
       keyword = Keyword.find keyword_id
 

--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Google
+  class ClientServiceError < StandardError; end
+
+  class SearchKeywordJob < ApplicationJob
+    queue_as :default
+
+    retry_on ClientServiceError, ArgumentError
+
+    def perform(keyword)
+      html_result = ClientService.new(keyword: keyword['name']).call
+
+      raise ClientServiceError unless html_result
+
+      update_keyword keyword['id'], ParserService.new(html_response: html_result).call
+    rescue ClientServiceError, ArgumentError => e
+      job_failed keyword['id']
+
+      raise e
+    end
+
+    private
+
+    def job_failed(keyword_id)
+      Keyword.update keyword_id, status: :failed
+    end
+
+    def update_keyword(keyword_id, attributes)
+      Keyword.transaction do
+        # rubocop:disable Rails/SkipsModelValidations
+        Keyword.find(keyword_id).result_links.insert_all attributes[:result_links]
+        # rubocop:enable Rails/SkipsModelValidations
+
+        Keyword.update keyword_id, attributes.except(:result_links)
+      end
+    end
+  end
+end

--- a/app/services/google/parser_service.rb
+++ b/app/services/google/parser_service.rb
@@ -25,12 +25,14 @@ module Google
       {
         ads_top_count: ads_top_count,
         ads_page_count: ads_page_count,
-        ads_top_urls: ads_top_urls,
-        ads_page_urls: ads_page_urls,
         non_ads_result_count: non_ads_result_count,
-        non_ads_urls: non_ads_urls,
         total_link_count: total_link_count,
-        html: html
+
+        html: html,
+
+        result_links: result_links,
+
+        status: :parsed
       }
     end
 
@@ -47,23 +49,37 @@ module Google
     end
 
     def ads_top_urls
-      document.css("##{AD_CONTAINER_ID} .#{ADWORDS_CLASS}").map { |a_tag| a_tag['href'] }
+      document.css("##{AD_CONTAINER_ID} .#{ADWORDS_CLASS}").filter_map { |a_tag| a_tag['href'].presence }
     end
 
     def ads_page_urls
-      document.css(".#{ADWORDS_CLASS}").map { |a_tag| a_tag['href'] }
+      document.css(".#{ADWORDS_CLASS}").filter_map { |a_tag| a_tag['href'].presence }
     end
 
     def non_ads_result_count
-      document.css(NON_ADS_RESULT_SELECTOR).count
+      document.css(NON_ADS_RESULT_SELECTOR).count { |a_tag| a_tag['href'].presence }
     end
 
     def non_ads_urls
-      document.css(NON_ADS_RESULT_SELECTOR).map { |a_tag| a_tag['href'] }
+      document.css(NON_ADS_RESULT_SELECTOR).filter_map { |a_tag| a_tag['href'].presence }
     end
 
     def total_link_count
       document.css('a').count
+    end
+
+    def result_links
+      results = result_link_map(ads_page_urls, :ads_page)
+      results += result_link_map(non_ads_urls, :non_ads)
+      results += result_link_map(ads_top_urls, :ads_top)
+
+      results
+    end
+
+    def result_link_map(urls, type)
+      urls.map do |url|
+        { url: url, link_type: type }
+      end
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module GoogleSearchRuby
     config.active_job.queue_adapter = :sidekiq
 
     # Prefix the queue name of all jobs with Rails ENV
-    config.active_job.queue_name_prefix = Rails.env
+    config.active_job.queue_name_prefix = nil
 
     # Compress the responses to reduce the size of html/json controller responses.
     config.middleware.use Rack::Deflater

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe CSVUploadForm, type: :form do
 
         expect(Keyword.where(name: 'dien may xanh, the gio di dong').count).to eq(1)
       end
+
+      it 'returns an array of 8 keyword_ids' do
+        form, = save_csv_file 'valid.csv'
+
+        expect(form.keyword_ids).to match_array(Keyword.select(:id).map(&:id))
+      end
     end
 
     context 'given too many keywords' do

--- a/spec/jobs/google/distribute_search_job_spec.rb
+++ b/spec/jobs/google/distribute_search_job_spec.rb
@@ -3,5 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe Google::DistributeSearchJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    context 'given 3 valid keywords' do
+      it 'queues a DistributedSearch job' do
+        keywords = Fabricate.times(3, :keyword).map(&:attributes)
+
+        expect { described_class.perform_later keywords }.to have_enqueued_job(described_class)
+      end
+
+      it 'queues 3 SearchKeyword jobs' do
+        keywords = Fabricate.times(3, :keyword).map(&:attributes)
+
+        expect { described_class.perform_now keywords }.to have_enqueued_job(Google::SearchKeywordJob).exactly(:thrice)
+      end
+    end
+
+    context 'given an empty array' do
+      it 'queues a DistributedSearch job' do
+        expect { described_class.perform_later [] }.to have_enqueued_job(described_class)
+      end
+
+      it 'does not queue the SearchKeyword jobs' do
+        expect { described_class.perform_now [] }.not_to have_enqueued_job(Google::SearchKeywordJob)
+      end
+    end
+  end
 end

--- a/spec/jobs/google/distribute_search_job_spec.rb
+++ b/spec/jobs/google/distribute_search_job_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Google::DistributeSearchJob, type: :job do
   describe '#perform' do
     context 'given 3 valid keywords' do
       it 'queues a DistributedSearch job' do
-        keywords = Fabricate.times(3, :keyword).map(&:attributes)
+        keywords = Fabricate.times(3, :keyword).map(&:id)
 
         expect { described_class.perform_later keywords }.to have_enqueued_job(described_class)
       end
 
       it 'queues 3 SearchKeyword jobs' do
-        keywords = Fabricate.times(3, :keyword).map(&:attributes)
+        keywords = Fabricate.times(3, :keyword).map(&:id)
 
         expect { described_class.perform_now keywords }.to have_enqueued_job(Google::SearchKeywordJob).exactly(:thrice)
       end

--- a/spec/jobs/google/distribute_search_job_spec.rb
+++ b/spec/jobs/google/distribute_search_job_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Google::DistributeSearchJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/jobs/google/search_keyword_job_spec.rb
+++ b/spec/jobs/google/search_keyword_job_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Google::SearchKeywordJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/jobs/google/search_keyword_job_spec.rb
+++ b/spec/jobs/google/search_keyword_job_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'queues the job', vcr: 'google_search/top_ads_1' do
         keyword = Fabricate(:keyword)
 
-        expect { described_class.perform_later keyword.attributes }.to have_enqueued_job(described_class)
+        expect { described_class.perform_later keyword.id }.to have_enqueued_job(described_class)
       end
 
       it 'saves all result_links in the DataBase', vcr: 'google_search/top_ads_1' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.result_links.count).to eq(46)
       end
@@ -24,7 +24,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'sets the keyword status as parsed', vcr: 'google_search/top_ads_1' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.reload.status).to eq('parsed')
       end
@@ -32,7 +32,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'sets the links counts with the right values', vcr: 'google_search/top_ads_1' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         keyword.reload
 
@@ -42,7 +42,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'sets the keyword html attribute', vcr: 'google_search/top_ads_1' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.reload.html).to be_present
       end
@@ -52,7 +52,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'sets the keyword status as failed', vcr: 'google_search/too_many_requests' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.reload.status).to eq('failed')
       end
@@ -68,7 +68,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'does not save any result_links', vcr: 'google_search/too_many_requests' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.reload.result_links.count).to eq(0)
       end
@@ -84,7 +84,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
       it 'does not set the html attribute', vcr: 'google_search/too_many_requests' do
         keyword = Fabricate(:keyword)
 
-        described_class.perform_now keyword.attributes
+        described_class.perform_now keyword.id
 
         expect(keyword.reload.html).not_to be_present
       end

--- a/spec/jobs/google/search_keyword_job_spec.rb
+++ b/spec/jobs/google/search_keyword_job_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Google::SearchKeywordJob, type: :job do
 
         load 'app/jobs/google/search_keyword_job.rb'
 
-        expect(described_class).to have_received(:retry_on).with(Google::ClientServiceError, ArgumentError)
+        expect(described_class).to have_received(:retry_on).with(Google::ClientServiceError, ArgumentError, { wait: 12.seconds })
       end
 
       it 'does not save any result_links', vcr: 'google_search/too_many_requests' do

--- a/spec/jobs/google/search_keyword_job_spec.rb
+++ b/spec/jobs/google/search_keyword_job_spec.rb
@@ -3,5 +3,91 @@
 require 'rails_helper'
 
 RSpec.describe Google::SearchKeywordJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    context 'given a valid request' do
+      it 'queues the job', vcr: 'google_search/top_ads_1' do
+        keyword = Fabricate(:keyword)
+
+        expect { described_class.perform_later keyword.attributes }.to have_enqueued_job(described_class)
+      end
+
+      it 'saves all result_links in the DataBase', vcr: 'google_search/top_ads_1' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.result_links.count).to eq(46)
+      end
+
+      it 'sets the keyword status as parsed', vcr: 'google_search/top_ads_1' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.reload.status).to eq('parsed')
+      end
+
+      it 'sets the links counts with the right values', vcr: 'google_search/top_ads_1' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        keyword.reload
+
+        expect(keyword.ads_top_count + keyword.ads_page_count + keyword.non_ads_result_count).to eq(46)
+      end
+
+      it 'sets the keyword html attribute', vcr: 'google_search/top_ads_1' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.reload.html).to be_present
+      end
+    end
+
+    context 'given a 422 too many requests error' do
+      it 'sets the keyword status as failed', vcr: 'google_search/too_many_requests' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.reload.status).to eq('failed')
+      end
+
+      it 'retries the job when an error is raised' do
+        allow(described_class).to receive(:retry_on)
+
+        load 'app/jobs/google/search_keyword_job.rb'
+
+        expect(described_class).to have_received(:retry_on).with(Google::ClientServiceError, ArgumentError)
+      end
+
+      it 'does not save any result_links', vcr: 'google_search/too_many_requests' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.reload.result_links.count).to eq(0)
+      end
+
+      it 'does not set any result count', vcr: 'google_search/too_many_requests' do
+        keyword = Fabricate(:keyword)
+
+        keyword.reload
+
+        expect([keyword.ads_top_count, keyword.ads_page_count, keyword.non_ads_result_count]).to all(be_nil)
+      end
+
+      it 'does not set the html attribute', vcr: 'google_search/too_many_requests' do
+        keyword = Fabricate(:keyword)
+
+        described_class.perform_now keyword.attributes
+
+        expect(keyword.reload.html).not_to be_present
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,8 +26,11 @@ RSpec.configure do |config|
 
   config.include Devise::Test::IntegrationHelpers, type: :system
 
+  config.include Devise::Test::ControllerHelpers, type: :request
+
   config.include DeviseHelpers::SystemHelpers
 
   config.include FileUploadHelpers::Form
   config.include FileUploadHelpers::System
+  config.include FileUploadHelpers::Request
 end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -120,19 +120,19 @@ describe API::V1::KeywordsController, type: :request do
   describe 'POST #create' do
     context 'given a valid file' do
       it 'saves the keywords in the DB', authenticated_api_user: true do
-        params = file_params 'valid.csv'
+        params = file_api_params 'valid.csv'
 
         expect { post :create, params: params }.to change(Keyword, :count).by(8)
       end
 
       it 'returns the upload_success meta message', authenticated_api_user: true do
-        post :create, params: file_params('valid.csv')
+        post :create, params: file_api_params('valid.csv')
 
         expect(JSON.parse(response.body)['meta']).to eq(I18n.t('csv.upload_success'))
       end
 
       it 'responds with a 200 OK status code', authenticated_api_user: true do
-        post :create, params: file_params('valid.csv')
+        post :create, params: file_api_params('valid.csv')
 
         expect(response.status).to eq(200)
       end
@@ -140,19 +140,19 @@ describe API::V1::KeywordsController, type: :request do
 
     context 'given an invalid file' do
       it 'does not save any new keyword', authenticated_api_user: true do
-        params = file_params 'too_many_keywords.csv'
+        params = file_api_params 'too_many_keywords.csv'
 
         expect { post :create, params: params }.to change(Keyword, :count).by(0)
       end
 
       it 'returns an errors object', authenticated_api_user: true do
-        post :create, params: file_params('too_many_keywords.csv')
+        post :create, params: file_api_params('too_many_keywords.csv')
 
         expect(JSON.parse(response.body)['errors'].keys).to contain_exactly('details', 'code', 'status')
       end
 
       it 'responds with a 422 Unprocessable Entity status code', authenticated_api_user: true do
-        post :create, params: file_params('too_many_keywords.csv')
+        post :create, params: file_api_params('too_many_keywords.csv')
 
         expect(response.status).to eq(422)
       end

--- a/spec/requests/keywords_controller_spec.rb
+++ b/spec/requests/keywords_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe KeywordsController, type: :request do
+  describe 'POST #create' do
+    context 'given a valid file' do
+      it 'queues a Google::SearchKeyword job', authenticated_request_user: true  do
+        expect { post :create, params: file_params('valid.csv') }.to have_enqueued_job(Google::DistributeSearchJob)
+      end
+    end
+
+    context 'given an invalid file' do
+      it 'does not queue any job', authenticated_request_user: true do
+        expect { post :create, params: file_params('too_many_keywords.csv') }.not_to have_enqueued_job
+      end
+    end
+  end
+end

--- a/spec/services/google/parser_service_spec.rb
+++ b/spec/services/google/parser_service_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe Google::ParserService, type: :service do
       it 'finds exactly the 3 top ads urls', vcr: 'google_search/top_ads_6' do
         result = Google::ClientService.new(keyword: 'vpn').call
 
-        expect(described_class.new(html_response: result).call[:ads_top_urls]).to contain_exactly('https://cloud.google.com/free', 'https://www.expressvpn.com/', 'https://www.top10vpn.com/best-vpn-for-vietnam/')
+        result_links = described_class.new(html_response: result).call[:result_links]
+
+        top_ads_urls = result_links.select { |link| link[:link_type] == :ads_top }.pluck(:url)
+
+        expect(top_ads_urls).to contain_exactly('https://cloud.google.com/free', 'https://www.expressvpn.com/', 'https://www.top10vpn.com/best-vpn-for-vietnam/')
       end
 
       it 'counts exactly 14 non ad results', vcr: 'google_search/top_ads_6' do
@@ -37,10 +41,14 @@ RSpec.describe Google::ParserService, type: :service do
         expect(described_class.new(html_response: result).call[:non_ads_result_count]).to eq(14)
       end
 
-      it 'gets 14 results', vcr: 'google_search/top_ads_6' do
+      it 'gets 14 non_ads result_links', vcr: 'google_search/top_ads_6' do
         result = Google::ClientService.new(keyword: 'vpn').call
 
-        expect(described_class.new(html_response: result).call[:non_ads_urls].count).to eq(14)
+        result_links = described_class.new(html_response: result).call[:result_links]
+
+        non_ads = result_links.select { |link| link[:link_type] == :non_ads }
+
+        expect(non_ads.length).to eq(14)
       end
 
       it 'gets exactly 113 links', vcr: 'google_search/top_ads_6' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ RSpec.configure do |config|
     sign_in Fabricate(:user)
   end
 
+  config.before(:each, authenticated_request_user: true) do
+    sign_in Fabricate(:user)
+  end
+
   config.before(:each, authenticated_api_user: true) do
     create_token_header
   end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -13,7 +13,7 @@ module DeviseHelpers
       click_button I18n.t('auth.sign_in')
     end
 
-    def sign_in(user)
+    def sign_in_system(user)
       login_as user, scope: :user
 
       user

--- a/spec/support/file_upload_helpers.rb
+++ b/spec/support/file_upload_helpers.rb
@@ -26,4 +26,16 @@ module FileUploadHelpers
       page.attach_file('csv_upload_form_file', Rails.root.join('spec', 'fixtures', 'files', 'csv', name), visible: :all)
     end
   end
+
+  module Request
+    def file_api_params(file_name)
+      path = Rails.root.join('spec', 'fixtures', 'files', 'csv', file_name)
+
+      { file: Rack::Test::UploadedFile.new(path, 'text/csv', true) }
+    end
+
+    def file_params(file_name)
+      { csv_upload_form: file_api_params(file_name) }
+    end
+  end
 end

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -66,10 +66,4 @@ module OAuthHelpers
 
     request.headers['Authorization'] = "Bearer #{access_token.token}"
   end
-
-  def file_params(file_name)
-    path = Rails.root.join('spec', 'fixtures', 'files', 'csv', file_name)
-
-    { file: Rack::Test::UploadedFile.new(path, 'text/csv', true) }
-  end
 end

--- a/spec/systems/keywords_list_spec.rb
+++ b/spec/systems/keywords_list_spec.rb
@@ -25,7 +25,7 @@ describe 'keywords list', type: :system do
 
   context 'given more keywords than what a page can contain' do
     it 'shows exactly 1 page of keywords' do
-      user = sign_in Fabricate(:user)
+      user = sign_in_system Fabricate(:user)
 
       Fabricate.times(Pagy::VARS[:items] + 1, :keyword, user: user)
 
@@ -35,7 +35,7 @@ describe 'keywords list', type: :system do
     end
 
     it 'shows an enabled pagination nav next button' do
-      user = sign_in Fabricate(:user)
+      user = sign_in_system Fabricate(:user)
 
       Fabricate.times(Pagy::VARS[:items] + 1, :keyword, user: user)
 
@@ -47,7 +47,7 @@ describe 'keywords list', type: :system do
 
   context 'given exactly 1 full page of keywords' do
     it 'shows exactly the max number of keywords one page can contain' do
-      user = sign_in Fabricate(:user)
+      user = sign_in_system Fabricate(:user)
 
       Fabricate.times(Pagy::VARS[:items], :keyword, user: user)
 
@@ -57,7 +57,7 @@ describe 'keywords list', type: :system do
     end
 
     it 'shows a disabled pagination nav next button' do
-      user = sign_in Fabricate(:user)
+      user = sign_in_system Fabricate(:user)
 
       Fabricate.times(Pagy::VARS[:items], :keyword, user: user)
 

--- a/spec/systems/login_spec.rb
+++ b/spec/systems/login_spec.rb
@@ -35,7 +35,7 @@ describe 'login', type: :system do
 
   context 'when the user signed in and reached the home page' do
     it 'does not redirect to the sign in page' do
-      sign_in Fabricate(:user)
+      sign_in_system Fabricate(:user)
       visit root_path
 
       expect(page).to have_current_path(root_path)


### PR DESCRIPTION
- #38 

## What happened

- Add result_links structure to `Google::ParserService`
- Add google distribute and search jobs
- Add `Google::SearchKeywordJob` tests
- Add `Google::DistributeSearchJob` tests

## Insight

- DistributeSearchJob
    - Enable to distribute KeywordSearch jobs from a list of `{:id, :name}`
- SearchKeywordJob
    - Run a single Keyword `searching` and `parsing`
    - Handle retry (default settings are wait 3seconds and retry up to 5 times)
    - Update status to failed from the first retry
 
## Proof Of Work

✅ Tests are covering (and passing) the following:
```
Google::SearchKeywordJob
  #perform
    given a 422 too many requests error
      retries the job when an error is raised
      does not save any result_links
      does not set any result count
      sets the keyword status as failed
      does not set the html attribute
    given a valid request
      queues the job
      sets the keyword html attribute
      saves all result_links in the DataBase
      sets the keyword status as parsed
      sets the links counts with the right values

Google::DistributeSearchJob
  #perform
    given 3 valid keywords
      queues a DistributedSearch job
      queues 3 SearchKeyword jobs
    given an empty array
      does not queue the SearchKeyword jobs
      queues a DistributedSearch job

Finished in 1.15 seconds (files took 2.14 seconds to load)
14 examples, 0 failures
```
