### PR TITLE
✅ [#11] [Backend] As a User, I get notified on the current progress of my keywords parsing

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module ApplicationCable
-  class Channel < ActionCable::Channel::Base
+  class Channel < Turbo::StreamsChannel
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -2,5 +2,20 @@
 
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      if (verified_user = env['warden'].user)
+        verified_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/google/search_progress_channel.rb
+++ b/app/channels/google/search_progress_channel.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Google
+  class SearchProgressChannel < ApplicationCable::Channel
+    def subscribed
+      stream_for current_user
+    end
+  end
+end

--- a/app/jobs/google/search_keyword_job.rb
+++ b/app/jobs/google/search_keyword_job.rb
@@ -20,6 +20,8 @@ module Google
       update_keyword_status keyword, :failed
 
       raise
+    ensure
+      SearchProgressJob.perform_now keyword.user_id
     end
 
     private

--- a/app/jobs/google/search_progress_job.rb
+++ b/app/jobs/google/search_progress_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Google
+  class SearchProgressJob < ApplicationJob
+    queue_as :default
+
+    def perform(user_id)
+      user = User.find(user_id)
+
+      SearchProgressChannel.broadcast_replace_to "toast_search_progress_stream:user_#{user.id}",
+                                                 target: 'toast_search_progress',
+                                                 partial: 'keywords/toast_search_progress',
+                                                 locals: { pending_count: user.keywords.pending.count }
+    end
+  end
+end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  context 'given a valid user' do
+    it 'connects successfully' do
+      user = Fabricate :user
+
+      authenticate_cable user
+
+      connect '/cable', headers: { 'X-USER-ID' => user.id }
+
+      expect(connect.current_user.id).to eq user.id
+    end
+  end
+
+  context 'given an unauthenticated user' do
+    it 'rejects the connection' do
+      authenticate_cable nil
+
+      expect { connect '/cable', headers: { 'X-USER-ID' => 0 } }.to have_rejected_connection
+    end
+  end
+end

--- a/spec/channels/google/search_progress_channel_spec.rb
+++ b/spec/channels/google/search_progress_channel_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Google::SearchProgressChannel, type: :channel do
+  it 'subscribes successfully' do
+    stub_connection current_user: Fabricate(:user)
+
+    subscribe
+
+    expect(subscription).to be_confirmed
+  end
+
+  it 'broadcasts a notification successfully' do
+    user = Fabricate :user
+    stub_connection current_user: user
+
+    subscribe
+
+    expect { described_class.broadcast_to user, data: 'test' }.to have_broadcasted_to(user).with(data: 'test').exactly(:once)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,4 +33,6 @@ RSpec.configure do |config|
   config.include FileUploadHelpers::Form
   config.include FileUploadHelpers::System
   config.include FileUploadHelpers::Request
+
+  config.include ChannelHelpers
 end

--- a/spec/support/channel_helpers.rb
+++ b/spec/support/channel_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ChannelHelpers
+  def authenticate_cable(user)
+    env = instance_double('env')
+
+    warden = instance_double('warden', user: user)
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationCable::Connection).to receive(:env).and_return(env)
+    # rubocop:enable RSpec/AnyInstance
+
+    allow(env).to receive(:[]).with('warden').and_return(warden)
+  end
+end


### PR DESCRIPTION
- #11 

## What happened

- Add authentication to the application cable connection
- Inherit the base channel from `Turbo::StreamsChannel`
- Add an application cable channel (`Google::SearchProgressChannel`)
- Add the `Google::SearchProgressJob` job to get notification data (from user_id) and broadcast a turbo-stream using that channel
- Call  `Google::SearchProgressJob#perform_now` once a keyword search job has been performed (using `ensure` to handle both happy/fail paths)

## Insight

Channel tests ensure the following:
- Only authenticated user can connect (and so subscribe)
- The channel can subscribe and broadcast

SearchKeywordJob as 2 additional tests to ensure the `SearchProgressJob` is called once with the right user_id: for the happy path as well as for the failure path.

A [partial view](https://github.com/malparty/google-search-ruby/pull/71/files#diff-688aa2137d64aef25bf838ed41a0e97a18dbd7af353076fde99eea79abdf6f20) has been created empty, why? 
- Turbo Stream helper will render a partial view. In order to prepare the backend, we need at least an empty partial view so that Turbo Stream won't raise an error.

`cable.yml` config has been switched from `async` to `redis`, why?
- When performing a job with `perform_later`, a new thread is created (as expected). Action Cable `async` config limit action cable to the main thread, thus preventing any other thread to broadcast. We need a `shared` place to run action cable channels, redis is solving this problem.

`Google::SearchKeywordJob` is calling `Google::SearchProgressJob` with `perform_now` instead of `perform_later`, why?
- Even these are 2x different jobs, I believe the progress notification should NOT be queued, but should be send ASAP once a SearchKeywordJob is done or failed. `perform_now` enables to remain in the same thread. So perform_now is called on purpose.

## Proof Of Work

### Channel Tests:
![image](https://user-images.githubusercontent.com/77609814/126100985-9526c21e-db7b-48a2-98d9-325f081054b0.png)

### SearchKeyword Job added tests:
```txt
Google::SearchKeywordJob
  #perform
    given a 422 too many requests error
      does not set the html attribute
      does not set any result count
      retries the job when an error is raised
      performs a SearchProgress job with the right user id  # HERE
      does not save any result_links
      sets the keyword status as failed
    given a valid request
      sets the keyword html attribute
      performs a SearchProgress job with the right user id  # HERE
      sets the keyword status as parsed
      sets the links counts with the right values
      saves all result_links in the DataBase
      queues the job

Finished in 1.26 seconds (files took 2.08 seconds to load)
12 examples, 0 failures
```


### Rails console:

- SearchProgressJob has been called during the keyword parsing 
```bash
[1] pry(main)> keyword_id = Keyword.pending.first.id
=> 435

[2] pry(main)> Google::SearchKeywordJob.perform_now keyword_id
```
SearchProgressJob is performed and the TurboStream notification is sent to the right user (see highlighted log bellow):
![image](https://user-images.githubusercontent.com/77609814/126100821-431a1d3a-0909-441c-8b85-d0aa40081663.png)

