### PR TITLE
[#75] [API] As a user, my keywords are being parsed in background

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -20,6 +20,8 @@ module API
 
       def create
         if csv_form.save(create_params[:file])
+          Google::DistributeSearchJob.perform_later(csv_form.keyword_ids)
+
           render json: create_success_response
         else
           render_errors(

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -136,6 +136,10 @@ describe API::V1::KeywordsController, type: :request do
 
         expect(response.status).to eq(200)
       end
+
+      it 'queues a Google::DistributeSearchJob job', authenticated_api_user: true do
+        expect { post :create, params: file_api_params('valid.csv') }.to have_enqueued_job(Google::DistributeSearchJob)
+      end
     end
 
     context 'given an invalid file' do
@@ -155,6 +159,10 @@ describe API::V1::KeywordsController, type: :request do
         post :create, params: file_api_params('too_many_keywords.csv')
 
         expect(response.status).to eq(422)
+      end
+
+      it 'does not queue any job', authenticated_request_user: true do
+        expect { post :create, params: file_api_params('too_many_keywords.csv') }.not_to have_enqueued_job
       end
     end
   end


### PR DESCRIPTION
- #75 

## What happened

- When a user upload a csv file from API, it will start automatically to search google and parse the keywords

## Insight

- Call background worker to start Keyword searches ASAP when a csv file has been uploaded via API
- Add tests to ensure the `DistributeSearchJob` is well enqueued 

## Proof Of Work

![image](https://user-images.githubusercontent.com/77609814/126134506-944a660d-a166-4f0e-8a5b-bd7f523aa74f.png)
