### PR TITLE
✅ [#12] [Frontend] As a User, I can see a list of my previous keyword results

### DIFF
--- a/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap/bootstrap.scss
@@ -29,7 +29,7 @@
 @import 'bootstrap/scss/offcanvas';
 @import 'bootstrap/scss/progress';
 //@import 'bootstrap/scss/media';
-//@import 'bootstrap/scss/list-group';
+@import 'bootstrap/scss/list-group';
 @import 'bootstrap/scss/close';
 //@import 'bootstrap/scss/toasts';
 //@import 'bootstrap/scss/modal';

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -28,7 +28,7 @@ class KeywordsController < ApplicationController
     keyword = Keyword.includes(:result_links).find show_params[:id]
 
     render locals: {
-      keyword: keyword
+      presenter: KeywordPresenter.new(keyword)
     }
   end
 

--- a/app/presenters/keyword_presenter.rb
+++ b/app/presenters/keyword_presenter.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class KeywordPresenter
+  attr_reader :keyword
+
+  def initialize(keyword)
+    @keyword = keyword
+  end
+
+  def result_link_types
+    keyword.result_links.group_by(&:link_type)
+  end
+
+  def created_at_date
+    keyword.created_at.strftime '%F'
+  end
+
+  def created_at_time
+    keyword.created_at.strftime '%T'
+  end
+
+  def url_title(url)
+    result = url.sub(%r{https?://(www.)?}, '').split('/')[0]
+
+    return result if result.present?
+
+    'google.com'
+  end
+
+  def google_link
+    "https://google.com/search?q=#{keyword.name}"
+  end
+
+  def result_link_type_icon(link_type)
+    case link_type
+    when :ads_top
+      'bi bi-file-earmark-arrow-up-fill'
+    when :ads_page
+      'bi bi-file-earmark-break-fill'
+    when :non_ads
+      'bi bi-file-check'
+    else
+      'bi bi-file-earmark-text'
+    end
+  end
+
+  def status_icon
+    case keyword.status.to_sym
+    when :pending
+      'bi bi-hourglass-split text-warning'
+    when :parsed
+      'bi bi-check-lg text-success'
+    else
+      'bi bi-bug text-danger'
+    end
+  end
+
+  def ads_top_count
+    keyword.ads_top_count || 0
+  end
+
+  def ads_page_count
+    keyword.ads_page_count || 0
+  end
+
+  def non_ads_result_count
+    keyword.non_ads_result_count || 0
+  end
+
+  def total_link_count
+    keyword.total_link_count || 0
+  end
+end

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,12 +1,12 @@
 <section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'frame_list_keywords' do %>
     <% if keywords.groups.any? %>
-      <% keywords.groups.each do |group_key, group_keywords| %>
-        <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
-      <% end %>
       <div class="d-flex justify-content-around">
         <%== pagy_bootstrap_nav(pagy) %>
       </div>
+      <% keywords.groups.each do |group_key, group_keywords| %>
+        <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
+      <% end %>
     <% else %>
       <div class="alert alert-light"><%= t('keywords.empty_list') %></div>
     <% end %>

--- a/app/views/keywords/_list_keywords_group.html.erb
+++ b/app/views/keywords/_list_keywords_group.html.erb
@@ -6,7 +6,9 @@
   </div>
   <ul class="list-inline mb-0">
     <% group_keywords.each do |keyword| %>
-      <li class="list-inline-item list-keyword-item"><%= keyword.name %></li>
+      <li class="list-inline-item list-keyword-item">
+        <%= link_to keyword.name, keyword_path(keyword.id), data: { turbo_frame: 'frame_keyword_show' } %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/app/views/keywords/_show_count_icons.html.erb
+++ b/app/views/keywords/_show_count_icons.html.erb
@@ -1,0 +1,18 @@
+<div class="row display-6">
+  <div class="col-3">
+    <i class="<%= presenter.result_link_type_icon :ads_top %>"></i>
+    <%= presenter.ads_top_count %>
+  </div>
+  <div class="col-3">
+    <i class="<%= presenter.result_link_type_icon :ads_page %>"></i>
+    <%= presenter.ads_page_count %>
+  </div>
+  <div class="col-3">
+    <i class="<%= presenter.result_link_type_icon :non_ads %>"></i>
+    <%= presenter.non_ads_result_count %>
+  </div>
+  <div class="col-3">
+    <i class="<%= presenter.result_link_type_icon :total_link_count %>"></i>
+    <%= presenter.total_link_count %>
+  </div>
+</div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -5,6 +5,9 @@
     </div>
     <div class="col-md-8 col-lg-9">
       <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
+
+      <%= turbo_frame_tag 'frame_keyword_show' do %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/keywords/show.html.erb
+++ b/app/views/keywords/show.html.erb
@@ -1,0 +1,44 @@
+<%= turbo_frame_tag 'frame_keyword_show' do %>
+  <div class="card keyword-card">
+    <div class="card-header">
+      <%= render 'show_count_icons', presenter: presenter %>
+    </div>
+    <div class="card-body">
+      <div class="d-flex justify-content-between align-items-center lead">
+        <h1 class="display-2 keyword-card--title">
+          <% if presenter.keyword.parsed? %>
+            <%= link_to keyword_preview_index_path(keyword_id: presenter.keyword.id), target: '_blank' do %><i class="bi bi-server"></i><% end %>
+          <% else %>
+            <%= link_to presenter.google_link, target: '_blank' do %><i class="bi bi-google"></i><% end %>
+          <% end %>
+          <%= presenter.keyword.name %>
+        </h1>
+        <div class="keyword-card--status">
+          <i class="<%= presenter.status_icon %>"></i>
+          <%= t("keyword.status.#{presenter.keyword.status}") %>
+        </div>
+        <div class="keyword-card--created-at">
+          <div><%= presenter.created_at_date %></div>
+          <div><%= presenter.created_at_time %></div>
+        </div>
+      </div>
+      <% presenter.result_link_types.each do |link_type| %>
+        <h3 class="mt-3">
+          <i class="<%= presenter.result_link_type_icon link_type[0].to_sym %>"></i>
+          <%= t("result_links.#{link_type[0]}") %>
+        </h3>
+        <div class="list-group">
+          <div class="row">
+            <% link_type[1].each do |result_link| %>
+              <div class="col-6 keyword-card--result-link">
+                <a href="<%= result_link.url %>" target="_blank" class="btn list-group-item list-group-item-action">
+                  <%= presenter.url_title result_link.url %>
+                </a>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/404.html.erb
+++ b/app/views/shared/404.html.erb
@@ -1,0 +1,4 @@
+<div class="container mt-3">
+  <h1 class="display-1"><%= t('not_found.title') %></h1>
+  <p><%= t('not_found.text') %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,14 @@ en:
   keywords:
     could_not_query: 'An error occurs when performing the Google Search, please try again.'
     empty_list: 'You do not have any keyword yet.'
+    status:
+      pending: 'Pending'
+      failed: 'Failed'
+      parsed: 'Parsed'
+  result_links:
+    non_ads: 'Non ad links'
+    ads_page: 'Page ad links'
+    ads_top: 'Top ad links'
   pagy:
     errors:
       overflow: 'There are not that many pages here! Max page is %{max_page}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,9 @@ en:
       wrong_count: 'The csv file should contain between 1 and 1000 keywords'
       wrong_type: 'Please ensure the provided file type is csv'
       bad_keyword_length: 'One or many keywords excess the max length of 255 characters.'
+  not_found:
+    title: '404 - Not Found'
+    text: 'The page you were looking for does not exist. You may have mistyped the address or the page may have moved.'
   min_char: 'characters minimum'
   confirm: 'Are you sure?'
   update: 'Update'

--- a/spec/presenters/keyword_presenter_spec.rb
+++ b/spec/presenters/keyword_presenter_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe KeywordPresenter, type: :presenter do
+  describe '#result_link_types' do
+    it 'returns a list grouped by link_types' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      expect(presenter.result_link_types.map { |link_type| link_type[0] }).to all(be_in(ResultLink.link_types.keys))
+    end
+
+    it 'returns a list with all result_links' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      result_links_list = presenter.result_link_types.map { |link_type| link_type[1] }.flatten.count
+
+      expect(result_links_list).to eq(presenter.keyword.result_links.length)
+    end
+  end
+
+  describe '#created_at_date' do
+    it 'returns a formatted date' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links, created_at: Time.zone.local(2021, 6, 1)))
+
+      expect(presenter.created_at_date).to eq('2021-06-01')
+    end
+  end
+
+  describe '#created_at_time' do
+    it 'returns a formatted time' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links, created_at: Time.zone.local(2021, 6, 1, 22, 45, 15)))
+
+      expect(presenter.created_at_time).to eq('22:45:15')
+    end
+  end
+
+  describe '#url_title' do
+    it 'returns domains only for a basic url' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.url_title('https://my-domain.com/a_path?some_variable=null')).to eq('my-domain.com')
+    end
+
+    it 'returns the sub domain and domain for a sub-domain url' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.url_title('https://sub-domain.my-domain.com/a_path?some_variable=null')).to eq('sub-domain.my-domain.com')
+    end
+
+    it 'does not return www' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.url_title('https://www.sub-domain.my-domain.com/a_path?some_variable=null')).to eq('sub-domain.my-domain.com')
+    end
+
+    it 'returns google.com for relative urls' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.url_title('/a_path?some_variable=null')).to eq('google.com')
+    end
+  end
+
+  describe '#ads_top_count' do
+    it 'returns the keyword ads_top_count' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      expect(presenter.ads_top_count).to eq(presenter.keyword.ads_top_count)
+    end
+
+    it 'returns 0 when ads_top_count is nil' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.ads_top_count).to be_zero
+    end
+  end
+
+  describe '#ads_page_count' do
+    it 'returns the keyword ads_page_count' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      expect(presenter.ads_page_count).to eq(presenter.keyword.ads_page_count)
+    end
+
+    it 'returns 0 when ads_page_count is nil' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.ads_page_count).to be_zero
+    end
+  end
+
+  describe '#non_ads_result_count' do
+    it 'returns the keyword non_ads_result_count' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      expect(presenter.non_ads_result_count).to eq(presenter.keyword.non_ads_result_count)
+    end
+
+    it 'returns 0 when non_ads_result_count is nil' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.non_ads_result_count).to be_zero
+    end
+  end
+
+  describe '#total_link_count' do
+    it 'returns the keyword total_link_count' do
+      presenter = described_class.new(Fabricate(:keyword_parsed_with_links))
+
+      expect(presenter.total_link_count).to eq(presenter.keyword.total_link_count)
+    end
+
+    it 'returns 0 when total_link_count is nil' do
+      presenter = described_class.new(Fabricate(:keyword))
+
+      expect(presenter.total_link_count).to be_zero
+    end
+  end
+end

--- a/spec/systems/keywords_show_spec.rb
+++ b/spec/systems/keywords_show_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'keywords#show', type: :system do
+  context 'given a valid id' do
+    it 'shows the keyword name' do
+      user = sign_in_system Fabricate(:user)
+
+      keyword = Fabricate(:keyword_parsed_with_links, user: user)
+
+      visit keyword_path({ id: keyword.id })
+
+      expect(find('.keyword-card--title')).to have_content(keyword.name)
+    end
+
+    it 'shows the keyword status' do
+      user = sign_in_system Fabricate(:user)
+
+      keyword = Fabricate(:keyword_parsed_with_links, user: user)
+
+      visit keyword_path({ id: keyword.id })
+
+      expect(find('.keyword-card--status')).to have_content(I18n.t("keywords.status.#{keyword.status}"))
+    end
+
+    it 'shows all the result_links' do
+      user = sign_in_system Fabricate(:user)
+
+      keyword = Fabricate(:keyword_parsed_with_links, user: user)
+
+      visit keyword_path({ id: keyword.id })
+
+      expect(find('.keyword-card')).to have_selector('.keyword-card--result-link', count: keyword.result_links.length)
+    end
+  end
+
+  context 'given an invalid id' do
+    it 'renders a custom 404 message', authenticated_user: true do
+      visit keyword_path({ id: 0 })
+
+      expect(page).to have_content(I18n.t('not_found.text')).and(have_content(I18n.t('not_found.title')))
+    end
+  end
+end


### PR DESCRIPTION
- #12 

## What happened

- [x] Add keyword#show view
- [x] Add 404 error view 
- [x] Add tests

## Insight

Again, we use Turbo from [Hotwire](https://hotwired.dev/) to load the `keywords#show` action into a new frame: `frame_keyword_show`.
In order to keep things simple, this frame apens right bellow the keyword-list. Pagination is not on top of the keyword list to make it more clear what belongs to what. 

I have used a presenter to format url, date/time and to provide the right icons. 
- tests are provided in the `spec/presenters/keyword_presenter_spec.rb`
- icon methods and `google url` methods are not tested: the logic being too basic it would makes more test-maintenance work than helping much. We can discuss this if you want :) 

## Proof Of Work

### Tests:
| presenter | system |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/126452683-3f6d2795-4c82-49c4-a556-bf2616bbb90d.png) | ![image](https://user-images.githubusercontent.com/77609814/126452850-dfc078c7-8971-43ae-b517-f9b9546eb23c.png) |


### UI: 

![image](https://user-images.githubusercontent.com/77609814/126452547-fb1e94e9-9e5a-41e4-a6f7-52394374842d.png)

![image](https://user-images.githubusercontent.com/77609814/126452810-04453f58-f35b-467e-843f-489690e7ba80.png)

