### PR TITLE
[#10] [Backend] As a User, I can search across keywords and results

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -7,7 +7,7 @@ module API
       include API::V1::Pagy::JSONAPIConcern
 
       def index
-        pagy, keywords_list = pagy(keywords_query.keywords)
+        pagy, keywords_list = pagy(keywords_query.keywords_filtered)
 
         render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
       end
@@ -35,7 +35,7 @@ module API
       private
 
       def keywords_query
-        @keywords_query ||= KeywordsQuery.new(current_user).call
+        @keywords_query ||= KeywordsQuery.new(current_user.keywords)
       end
 
       def csv_form

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -7,7 +7,7 @@ module API
       include API::V1::Pagy::JSONAPIConcern
 
       def index
-        pagy, keywords_list = pagy(keywords)
+        pagy, keywords_list = pagy(keywords_query.keywords)
 
         render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
       end
@@ -34,8 +34,8 @@ module API
 
       private
 
-      def keywords
-        KeywordsQuery.new(current_user).call
+      def keywords_query
+        @keywords_query ||= KeywordsQuery.new(current_user).call
       end
 
       def csv_form

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -4,10 +4,12 @@ class KeywordsController < ApplicationController
   include Pagy::Backend
 
   def index
-    pagy, keywords_list = pagy(keywords)
+    pagy, keywords_list = pagy(keywords_query.keywords)
 
     render locals: {
-      pagy: pagy, keywords: KeywordsCollectionPresenter.new(keywords_list),
+      pagy: pagy,
+      keywords: KeywordsCollectionPresenter.new(keywords_list),
+      url_match_count: keywords_query.url_match_count,
       csv_form: csv_form
     }
   end
@@ -34,8 +36,8 @@ class KeywordsController < ApplicationController
 
   private
 
-  def keywords
-    KeywordsQuery.new(current_user).call(index_params)
+  def keywords_query
+    @keywords_query ||= KeywordsQuery.new(current_user).call(index_params)
   end
 
   def csv_form

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -35,7 +35,7 @@ class KeywordsController < ApplicationController
   private
 
   def keywords
-    KeywordsQuery.new(current_user).call
+    KeywordsQuery.new(current_user).call(index_params)
   end
 
   def csv_form
@@ -44,6 +44,9 @@ class KeywordsController < ApplicationController
 
   def save_csv_file
     csv_form.save(create_params[:csv_upload_form][:file])
+
+  def index_params
+    params.permit(KeywordsQuery::QUERY_PARAMS)
   end
 
   def create_params

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -4,7 +4,7 @@ class KeywordsController < ApplicationController
   include Pagy::Backend
 
   def index
-    pagy, keywords_list = pagy(keywords_query.keywords)
+    pagy, keywords_list = pagy(keywords_query.keywords_filtered)
 
     render locals: {
       pagy: pagy,
@@ -37,7 +37,7 @@ class KeywordsController < ApplicationController
   private
 
   def keywords_query
-    @keywords_query ||= KeywordsQuery.new(current_user).call(index_params)
+    @keywords_query ||= KeywordsQuery.new(current_user.keywords, index_params)
   end
 
   def csv_form

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -46,6 +46,7 @@ class KeywordsController < ApplicationController
 
   def save_csv_file
     csv_form.save(create_params[:csv_upload_form][:file])
+  end
 
   def index_params
     params.permit(KeywordsQuery::QUERY_PARAMS)

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -10,6 +10,7 @@ class KeywordsController < ApplicationController
       pagy: pagy,
       keywords: KeywordsCollectionPresenter.new(keywords_list),
       url_match_count: keywords_query.url_match_count,
+      filter_error: keywords_query.error,
       csv_form: csv_form
     }
   end
@@ -49,7 +50,7 @@ class KeywordsController < ApplicationController
   end
 
   def index_params
-    params.permit(KeywordsQuery::QUERY_PARAMS)
+    params.permit(Filter::QUERY_PARAMS)
   end
 
   def create_params

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Filter
+  include ActiveModel::Model
+
+  QUERY_PARAMS = [:url_pattern, :keyword_pattern, { link_types: [] }].freeze
+  PATTERN_REGEXP =
+    %r{\A\^?((\[[\\\-/:.\w]+\])|([\\\-/:.\w]+)|(\(([\\\-/:.\w]+)\|?([\\\-/:.\w]+)\)))[+?*]?(\{\d+(,\d?)?\})?\$?\Z}
+    .freeze
+
+  attr_accessor :keyword_pattern, :url_pattern, :link_types
+
+  validates :keyword_pattern, format: { with: PATTERN_REGEXP }, allow_blank: true
+  validates :url_pattern, format: { with: PATTERN_REGEXP }, allow_blank: true
+  validate :link_types_exist?
+
+  def self.from_params(params)
+    Filter.new keyword_pattern: params[:keyword_pattern],
+               url_pattern: params[:url_pattern],
+               link_types: params[:link_types]&.map(&:to_i)&.uniq
+  end
+
+  def result_link_filter_exist?
+    url_pattern.present? || link_types.present?
+  end
+
+  protected
+
+  def link_types_exist?
+    return if link_types_valid?
+
+    errors.add :link_types, I18n.t('filters.value_error')
+  end
+
+  def link_types_valid?
+    link_types.blank? || link_types.all? { |link_type| link_type >= 0 && ResultLink.link_types.keys[link_type] }
+  end
+end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -17,7 +17,7 @@ class Filter
   def self.from_params(params)
     Filter.new keyword_pattern: params[:keyword_pattern],
                url_pattern: params[:url_pattern],
-               link_types: params[:link_types]&.map(&:to_i)&.uniq
+               link_types: params[:link_types]&.select(&:present?)&.map(&:to_i)&.uniq
   end
 
   def result_link_filter_exist?

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class KeywordsQuery
-  QUERY_PARAMS = %i[url_pattern keyword_pattern].freeze
+  QUERY_PARAMS = [:url_pattern, :keyword_pattern, { link_types: [] }].freeze
 
   attr_reader :keywords, :url_match_count
 
@@ -13,35 +13,46 @@ class KeywordsQuery
   def call(params = {})
     @keyword_pattern = params[:keyword_pattern]
     @url_pattern = params[:url_pattern]
+    @link_types = params[:link_types]
 
-    where_keyword_pattern
+    where_name
 
-    where_url_pattern
+    where_result_links
 
     order_by_name
 
-    @url_match_count = result_links_where_url_pattern.count
+    @url_match_count = result_links_filtered.count
 
     self
   end
 
   private
 
-  attr_reader :user, :keyword_pattern, :url_pattern
+  attr_reader :user, :keyword_pattern, :url_pattern, :link_types
 
   def order_by_name
     @keywords = keywords.order(:name)
   end
 
-  def where_keyword_pattern
+  def where_name
     @keywords = keywords.where('name ~* ?', keyword_pattern) if keyword_pattern.present?
   end
 
-  def where_url_pattern
-    @keywords = keywords.where(result_links: result_links_where_url_pattern) if url_pattern.present?
+  def where_result_links
+    @keywords = keywords.where(result_links: result_links_filtered) if filter_on_result_link?
   end
 
-  def result_links_where_url_pattern
-    ResultLink.where(keyword: user.keywords).where('url ~* ?', url_pattern)
+  def result_links_filtered
+    result_links = ResultLink.where(keyword: user.keywords)
+
+    result_links = result_links.where('url ~* ?', url_pattern) if url_pattern.present?
+
+    result_links = result_links.where(link_type: link_types) if link_types.present?
+
+    result_links
+  end
+
+  def filter_on_result_link?
+    url_pattern.present? || link_types.present?
   end
 end

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -3,31 +3,45 @@
 class KeywordsQuery
   QUERY_PARAMS = %i[url_pattern keyword_pattern].freeze
 
+  attr_reader :keywords, :url_match_count
+
   def initialize(user)
+    @user = user
     @keywords = user.keywords.select(Keyword.column_names.excluding('html'))
   end
 
   def call(params = {})
-    where_keyword_pattern params[:keyword_pattern] if params[:keyword_pattern].present?
+    @keyword_pattern = params[:keyword_pattern]
+    @url_pattern = params[:url_pattern]
 
-    where_url_pattern params[:url_pattern] if params[:url_pattern].present?
+    where_keyword_pattern
+
+    where_url_pattern
 
     order_by_name
+
+    @url_match_count = result_links_where_url_pattern.count
+
+    self
   end
 
   private
 
-  attr_reader :keywords
+  attr_reader :user, :keyword_pattern, :url_pattern
 
   def order_by_name
     @keywords = keywords.order(:name)
   end
 
-  def where_keyword_pattern(pattern)
-    @keywords = keywords.where('name ~* ?', pattern)
+  def where_keyword_pattern
+    @keywords = keywords.where('name ~* ?', keyword_pattern) if keyword_pattern.present?
   end
 
-  def where_url_pattern(pattern)
-    @keywords = keywords.where(result_links: ResultLink.where('url ~* ?', pattern))
+  def where_url_pattern
+    @keywords = keywords.where(result_links: result_links_where_url_pattern) if url_pattern.present?
+  end
+
+  def result_links_where_url_pattern
+    ResultLink.where(keyword: user.keywords).where('url ~* ?', url_pattern)
   end
 end

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class KeywordsQuery
+  QUERY_PARAMS = %i[url_pattern keyword_pattern].freeze
+
   def initialize(user)
     @keywords = user.keywords.select(Keyword.column_names.excluding('html'))
   end
 
-  def call
+  def call(params = {})
+    where_keyword_pattern params[:keyword_pattern] if params[:keyword_pattern].present?
+
+    where_url_pattern params[:url_pattern] if params[:url_pattern].present?
+
     order_by_name
   end
 
@@ -14,6 +20,14 @@ class KeywordsQuery
   attr_reader :keywords
 
   def order_by_name
-    keywords.order(:name)
+    @keywords = keywords.order(:name)
+  end
+
+  def where_keyword_pattern(pattern)
+    @keywords = keywords.where('name ~* ?', pattern)
+  end
+
+  def where_url_pattern(pattern)
+    @keywords = keywords.where(result_links: ResultLink.where('url ~* ?', pattern))
   end
 end

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -3,56 +3,56 @@
 class KeywordsQuery
   QUERY_PARAMS = [:url_pattern, :keyword_pattern, { link_types: [] }].freeze
 
-  attr_reader :keywords, :url_match_count
+  def initialize(relation, filters = {})
+    @relation = relation
 
-  def initialize(user)
-    @user = user
-    @keywords = user.keywords.select(Keyword.column_names.excluding('html'))
+    @keyword_pattern = filters[:keyword_pattern]
+    @url_pattern = filters[:url_pattern]
+    @link_types = filters[:link_types]&.reject(&:empty?)
   end
 
-  def call(params = {})
-    @keyword_pattern = params[:keyword_pattern]
-    @url_pattern = params[:url_pattern]
-    @link_types = params[:link_types]
+  def keywords_filtered
+    scope = without_html_column(relation)
 
-    where_name
+    scope = filter_by_name(scope) if keyword_pattern.present?
+    scope = filter_by_result_links(scope) if result_link_filter_exist?
 
-    where_result_links
+    order_by_name(scope)
+  end
 
-    order_by_name
-
-    @url_match_count = result_links_filtered.count
-
-    self
+  def url_match_count
+    result_links_filtered.count
   end
 
   private
 
-  attr_reader :user, :keyword_pattern, :url_pattern, :link_types
+  attr_reader :relation, :keyword_pattern, :url_pattern, :link_types
 
-  def order_by_name
-    @keywords = keywords.order(:name)
+  def without_html_column(scope)
+    scope.select(Keyword.column_names.excluding('html'))
   end
 
-  def where_name
-    @keywords = keywords.where('name ~* ?', keyword_pattern) if keyword_pattern.present?
+  def order_by_name(scope)
+    scope.order(:name)
   end
 
-  def where_result_links
-    @keywords = keywords.where(result_links: result_links_filtered) if filter_on_result_link?
+  def filter_by_name(scope)
+    scope.where('name ~* ?', keyword_pattern)
+  end
+
+  def filter_by_result_links(scope)
+    scope.where(result_links: result_links_filtered)
   end
 
   def result_links_filtered
-    result_links = ResultLink.where(keyword: user.keywords)
-
+    result_links = ResultLink.where(keyword: relation)
     result_links = result_links.where('url ~* ?', url_pattern) if url_pattern.present?
-
     result_links = result_links.where(link_type: link_types) if link_types.present?
 
     result_links
   end
 
-  def filter_on_result_link?
+  def result_link_filter_exist?
     url_pattern.present? || link_types.present?
   end
 end

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -1,32 +1,35 @@
 # frozen_string_literal: true
 
 class KeywordsQuery
-  QUERY_PARAMS = [:url_pattern, :keyword_pattern, { link_types: [] }].freeze
-
-  def initialize(relation, filters = {})
+  def initialize(relation, filter_params = {})
     @relation = relation
-
-    @keyword_pattern = filters[:keyword_pattern]
-    @url_pattern = filters[:url_pattern]
-    @link_types = filters[:link_types]&.reject(&:empty?)
+    @filter = Filter.from_params(filter_params)
   end
 
   def keywords_filtered
+    return Keyword.none unless filter.valid?
+
     scope = without_html_column(relation)
 
-    scope = filter_by_name(scope) if keyword_pattern.present?
-    scope = filter_by_result_links(scope) if result_link_filter_exist?
+    scope = filter_by_name(scope) if filter.keyword_pattern.present?
+    scope = filter_by_result_links(scope) if filter.result_link_filter_exist?
 
     order_by_name(scope)
   end
 
   def url_match_count
+    return 0 unless filter.valid?
+
     result_links_filtered.count
+  end
+
+  def error
+    filter.errors.full_messages.join '. '
   end
 
   private
 
-  attr_reader :relation, :keyword_pattern, :url_pattern, :link_types
+  attr_reader :relation, :filter
 
   def without_html_column(scope)
     scope.select(Keyword.column_names.excluding('html'))
@@ -37,7 +40,7 @@ class KeywordsQuery
   end
 
   def filter_by_name(scope)
-    scope.where('name ~* ?', keyword_pattern)
+    scope.where('name ~* ?', filter.keyword_pattern)
   end
 
   def filter_by_result_links(scope)
@@ -46,13 +49,9 @@ class KeywordsQuery
 
   def result_links_filtered
     result_links = ResultLink.where(keyword: relation)
-    result_links = result_links.where('url ~* ?', url_pattern) if url_pattern.present?
-    result_links = result_links.where(link_type: link_types) if link_types.present?
+    result_links = result_links.where('url ~* ?', filter.url_pattern) if filter.url_pattern.present?
+    result_links = result_links.where(link_type: filter.link_types) if filter.link_types.present?
 
     result_links
-  end
-
-  def result_link_filter_exist?
-    url_pattern.present? || link_types.present?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en:
   waiting_confirmation_for: 'Currently waiting confirmation for'
   forgot_password: 'Forgot your password?'
   my_profile: 'My Profile'
-  filters: 'Filters'
+  filters:
+    filters: 'Filters'
+    value_error: 'has wrong value'
   loading: 'Loading'
   record_not_found: 'The requested resource could not be found.'

--- a/spec/fabricators/keyword_fabricator.rb
+++ b/spec/fabricators/keyword_fabricator.rb
@@ -17,5 +17,5 @@ Fabricator(:keyword_parsed, from: :keyword) do
 end
 
 Fabricator(:keyword_parsed_with_links, from: :keyword_parsed) do
-  result_links(count: FFaker.rand(10))
+  result_links(count: FFaker.rand(10) + 1)
 end

--- a/spec/models/filter_spec.rb
+++ b/spec/models/filter_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filter, type: :model do
+  describe 'Validations' do
+    context 'given valid keyword_pattern and url_pattern' do
+      it 'is valid' do
+        filter = described_class.new keyword_pattern: '^[0-9]*$', url_pattern: '^[htps]'
+
+        expect(filter).to be_valid
+      end
+    end
+
+    context 'given valid link_types' do
+      it 'is valid' do
+        filter = described_class.new link_types: [ResultLink.link_types[:ads_top], ResultLink.link_types[:non_ads]]
+
+        expect(filter).to be_valid
+      end
+    end
+
+    context 'given a filter from_params' do
+      it 'is a Filter object' do
+        params = { keyword_pattern: 'keyword', url_pattern: '^https://', link_types: ['', ResultLink.link_types[:ads_top].to_s] }
+
+        filter = described_class.from_params params
+
+        expect(filter.class).to eq(described_class)
+      end
+
+      it 'is valid' do
+        params = { keyword_pattern: 'keyword', url_pattern: '^https://', link_types: ['', 'ads_top'] }
+
+        filter = described_class.from_params params
+
+        expect(filter).to be_valid
+      end
+    end
+
+    context 'given a filter from_params with empty params' do
+      it 'is a Filter object' do
+        filter = described_class.from_params({})
+
+        expect(filter.class).to eq(described_class)
+      end
+
+      it 'is valid' do
+        filter = described_class.from_params({})
+
+        expect(filter).to be_valid
+      end
+    end
+
+    context 'given no attribute' do
+      it 'is valid' do
+        filter = described_class.new
+
+        expect(filter).to be_valid
+      end
+    end
+
+    context 'given a bad keyword_pattern' do
+      it 'is not valid' do
+        filter = described_class.new keyword_pattern: '?'
+
+        expect(filter).not_to be_valid
+      end
+
+      it 'has an error message' do
+        filter = described_class.new keyword_pattern: '?'
+
+        filter.validate
+
+        expect(filter.errors.full_messages).to be_present
+      end
+    end
+
+    context 'given a bad url_pattern' do
+      it 'is not valid' do
+        filter = described_class.new url_pattern: '?'
+
+        expect(filter).not_to be_valid
+      end
+
+      it 'has an error message' do
+        filter = described_class.new url_pattern: '?'
+
+        filter.validate
+
+        expect(filter.errors.full_messages).to be_present
+      end
+    end
+
+    context 'given a bad link_types attribute' do
+      it 'is not valid' do
+        filter = described_class.new(link_types: [-1, ResultLink.link_types[:ads_top]])
+
+        expect(filter).not_to be_valid
+      end
+
+      it 'has an error message' do
+        filter = described_class.new(link_types: [-1, ResultLink.link_types[:ads_top]])
+
+        filter.validate
+
+        expect(filter.errors.full_messages).to be_present
+      end
+    end
+  end
+
+  describe '#result_link_filter_exist?' do
+    context 'given no params' do
+      it 'returns false' do
+        filter = described_class.new
+
+        expect(filter.result_link_filter_exist?).to be(false)
+      end
+    end
+
+    context 'given an url_pattern param' do
+      it 'returns true' do
+        filter = described_class.new({ url_pattern: '^https' })
+
+        expect(filter.result_link_filter_exist?).to be(true)
+      end
+    end
+
+    context 'given a link_types param' do
+      it 'returns true' do
+        filter = described_class.new({ link_types: [ResultLink.link_types[:ads_top]] })
+
+        expect(filter.result_link_filter_exist?).to be(true)
+      end
+    end
+
+    context 'given both url_pattern and link_types params' do
+      it 'returns true' do
+        filter = described_class.new({ url_pattern: '^https', link_types: [ResultLink.link_types[:ads_top]] })
+
+        expect(filter.result_link_filter_exist?).to be(true)
+      end
+    end
+  end
+
+  describe 'PATTERN_REGEXP' do
+    context 'given valid string' do
+      it { expect('simple'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('^startWith'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('endWith$'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]{5}'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]{5,}'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]{5,4}'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]?'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]*'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('[a-z]+'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('^(abc){5}$'.match described_class::PATTERN_REGEXP).not_to be_nil }
+      it { expect('^(a|b){5}$'.match described_class::PATTERN_REGEXP).not_to be_nil }
+    end
+
+    context 'given an invalid string' do
+      it { expect('?'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('*'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('+'.match described_class::PATTERN_REGEXP).to be_nil }
+
+      it { expect('['.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('[as'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('^[as'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('^as]'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect(']'.match described_class::PATTERN_REGEXP).to be_nil }
+
+      it { expect('('.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('(as'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('^(as'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect('^as)'.match described_class::PATTERN_REGEXP).to be_nil }
+      it { expect(')'.match described_class::PATTERN_REGEXP).to be_nil }
+    end
+  end
+end

--- a/spec/models/filter_spec.rb
+++ b/spec/models/filter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Filter, type: :model do
     end
 
     context 'given a filter from_params' do
-      it 'is a Filter object' do
+      it 'returns a Filter object' do
         params = { keyword_pattern: 'keyword', url_pattern: '^https://', link_types: ['', ResultLink.link_types[:ads_top].to_s] }
 
         filter = described_class.from_params params
@@ -39,7 +39,7 @@ RSpec.describe Filter, type: :model do
     end
 
     context 'given a filter from_params with empty params' do
-      it 'is a Filter object' do
+      it 'returns a Filter object' do
         filter = described_class.from_params({})
 
         expect(filter.class).to eq(described_class)

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe KeywordsQuery, type: :query do
     end
 
     context 'given many users with keywords' do
-      it 'returns only keywords from the initialized user' do
+      it 'returns only keywords from the authenticated user' do
         users = Fabricate.times(2, :user)
         Fabricate.times(10, :keyword, user: users[0])
         Fabricate.times(15, :keyword, user: users[1])
@@ -44,7 +44,7 @@ RSpec.describe KeywordsQuery, type: :query do
         expect(query.keywords_filtered.map(&:user_id)).to all(eq(users[0].id))
       end
 
-      it 'only counts URL matches from the initialized user' do
+      it 'counts only the URL matches for the authenticated user' do
         users = Fabricate.times(2, :user)
         Fabricate.times(10, :keyword_parsed_with_links, user: users[0])
         Fabricate.times(15, :keyword_parsed_with_links, user: users[1])
@@ -106,7 +106,7 @@ RSpec.describe KeywordsQuery, type: :query do
     end
 
     context 'given an expression as url_pattern' do
-      it 'returns only keywords having any result_link whose url matches that pattern' do
+      it 'returns only keywords having any result_link whose URL matches that pattern' do
         keyword = Fabricate.times(10, :keyword_parsed_with_links, user: Fabricate(:user))[4]
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
@@ -116,7 +116,7 @@ RSpec.describe KeywordsQuery, type: :query do
         expect(query.keywords_filtered.map(&:name)).to eq([keyword.name])
       end
 
-      it 'counts the right url matches' do
+      it 'counts the right URL matches' do
         keyword = Fabricate.times(10, :keyword_parsed_with_links, user: Fabricate(:user))[4]
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
@@ -138,7 +138,7 @@ RSpec.describe KeywordsQuery, type: :query do
     end
   end
 
-  context 'given both url and keyword patterns' do
+  context 'given both URL and keyword patterns' do
     it 'returns exactly the right keywords' do
       keyword = Fabricate.times(10, :keyword_parsed_with_links, user: Fabricate(:user))[3]
 
@@ -161,7 +161,7 @@ RSpec.describe KeywordsQuery, type: :query do
       expect(query.keywords_filtered.map(&:name)).to eq(%w[world world])
     end
 
-    it 'counts the right url matches' do
+    it 'counts the right URL matches' do
       keywords = Fabricate.times(10, :keyword_parsed_with_links, user: Fabricate(:user), name: 'world')
 
       keywords.take(2).each { |keyword| keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs') }
@@ -173,7 +173,7 @@ RSpec.describe KeywordsQuery, type: :query do
   end
 
   context 'given a unique link_type' do
-    it 'counts only url with this link_type' do
+    it 'counts only URLs with this link_type' do
       user = Fabricate(:user)
 
       Fabricate.times(5, :keyword_parsed, user: user).each { |keyword| Fabricate(:result_link, keyword: keyword, link_type: :ads_top) }


### PR DESCRIPTION
- #10 

## What happened

- [x] Add url and keyword patterns in KeywordsQuery
- [x] Add pattern tests in KeywordsQuery query tests
- [x] Add link_type in url filter
- [x] Add URL match count
- [x] Add link_type filter tests
- [x] Add match count tests
- [x] Add tests to cover filter validations

## Insight

- Only 3x filters will solve the specification needs (url_pattern, keyword_pattern & link_types). 
    The KeywordsQuery returns a `url_match_count` in addition to the `keywords` array (on which we can get the length).
    - ✅ How many URLs contain the word “technology” in AdWords.
    > url_pattern + link_types (as checkboxes in UI, array in API)
    - ✅ How many times a specific URL shows up in stored search results. 
    > url_pattern + url_match_count
    - ✅ How many keywords have URLs in stored search results with 2 or more “/” or 1 or more “>”. 
    > url_pattern: '(.*\/.*){2}'
- Tests covers all 3 filters as well as the url_match_count

## Proof Of Work

### Tests are covering the following:

| Query Object | Filter model |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/127292236-6056e4bf-b636-463e-b62e-2e750df6eb60.png) | ![image](https://user-images.githubusercontent.com/77609814/127293035-359a4361-4acb-43c3-8e97-b0a198590c35.png) ![image](https://user-images.githubusercontent.com/77609814/127292313-f5ef20d5-834a-4e28-98e1-16011f1463d5.png) | 


