### PR TITLE
✅ [#20] [API] As a User, I can search across keywords and results

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -9,7 +9,11 @@ module API
       def index
         pagy, keywords_list = pagy(keywords_query.keywords_filtered)
 
-        render json: KeywordSerializer.new(keywords_list, pagy_options(pagy))
+        options = pagy_options(pagy)
+
+        options[:meta] = options[:meta].merge(url_match_count: keywords_query.url_match_count)
+
+        render json: KeywordSerializer.new(keywords_list, options)
       end
 
       def show
@@ -35,7 +39,7 @@ module API
       private
 
       def keywords_query
-        @keywords_query ||= KeywordsQuery.new(current_user.keywords)
+        @keywords_query ||= KeywordsQuery.new(current_user.keywords, index_params)
       end
 
       def csv_form
@@ -50,6 +54,10 @@ module API
         {
           meta: I18n.t('csv.upload_success')
         }
+      end
+
+      def index_params
+        params.permit(Filter::QUERY_PARAMS)
       end
 
       def show_params

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -65,5 +65,7 @@ module OAuthHelpers
     access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
 
     request.headers['Authorization'] = "Bearer #{access_token.token}"
+
+    user
   end
 end


### PR DESCRIPTION
- #20 

## What happened

- [x] Add query params to api::v1::keywords controller
- [x] Add api request tests for KeywordsQuery params keywornd_pattern, url_pattern and link_types

## Insight

- API now takes filters optional params (`keyword_pattern:string`, `url_pattern:string` and `file_types:[]`)
- `url_match_count` is added in API response 'meta' element. As page already have some meta data, we need to merge both hashes.

## Proof Of Work

### API
- Full documentation updated [here](https://documenter.getpostman.com/view/16135891/TzeTKqCb)
    It includes 2 filters examples:
    ![image](https://user-images.githubusercontent.com/77609814/126746084-a031d246-754b-4809-8d76-cbea61ac7b93.png)

- response has only it's meta element changed:
```json
"meta": {
    "total_pages": 1,
    "url_match_count": 2
},
```

### Tests

![image](https://user-images.githubusercontent.com/77609814/126746243-60b36516-e071-41ff-94f1-1ff34d9ee60b.png)

