### PR TITLE
[#15] [Frontend] As a User, I can search across keywords and results

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -8,7 +8,7 @@ class KeywordsController < ApplicationController
 
     render locals: {
       pagy: pagy,
-      keywords: KeywordsCollectionPresenter.new(keywords_list),
+      presenter: KeywordsCollectionPresenter.new(keywords_list),
       url_match_count: keywords_query.url_match_count,
       filter_error: keywords_query.error,
       csv_form: csv_form

--- a/app/presenters/keywords_collection_presenter.rb
+++ b/app/presenters/keywords_collection_presenter.rb
@@ -5,7 +5,7 @@ class KeywordsCollectionPresenter
     @keywords = keywords
   end
 
-  def groups
+  def keyword_groups
     keywords.group_by { |keyword| keyword.name[0].upcase.to_sym }
   end
 

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -32,7 +32,7 @@
     <i class="bi bi-info-square"></i>
     <%= t('filters.cheatsheet') %>:
     <ul class="list-group">
-      <li class="list-group-item list-group-item-light"><code>a|b</code> 'a' or 'b'</li>
+      <li class="list-group-item list-group-item-light"><code>(a|b)</code> 'a' or 'b'</li>
       <li class="list-group-item list-group-item-light"><code>a*</code> '', 'a', 'aaaa', ...</li>
       <li class="list-group-item list-group-item-light"><code>a+</code> 'a', 'aaaa', ...</li>
       <li class="list-group-item list-group-item-light"><code>a?</code> 'a' or ''</li>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('filters.total_of_keywords', keywords_count: keywords_count) %>
   </p>
-  <%= form_with url: keywords_path, method: :get, class: 'form-filters', data:{turbo:true, turbo_frame:'frame_list_keywords'} do |form| %>
+  <%= form_with url: keywords_path, method: :get, class: 'form-filters', data: { turbo: true, turbo_frame: 'frame_list_keywords' } do |form| %>
     <div>
       <%= form.label :keyword_pattern, class: 'form-label' do %>
         <i class="bi bi-list-check"></i> <%= t('filters.by_keyword') %>...

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('filters.total_of_keywords', keywords_count: keywords_count) %>
   </p>
-  <%= form_with url: keywords_path, method: :get, class: 'form-filters', data: { turbo: true, turbo_frame: 'frame_list_keywords' } do |form| %>
+  <%= form_with url: keywords_path, method: :get, class: 'form-filter', data: { turbo: true, turbo_frame: 'frame_list_keywords' } do |form| %>
     <div>
       <%= form.label :keyword_pattern, class: 'form-label' do %>
         <i class="bi bi-list-check"></i> <%= t('filters.by_keyword') %>...

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -2,34 +2,32 @@
   <p>
     <%= t('filters.total_of_keywords', keywords_count: keywords_count) %>
   </p>
-  <form action="<%= keywords_path %>" method="GET" class="form-filters" data-turbo="true" data-turbo-frame="frame_list_keywords">
+  <%= form_with url: keywords_path, method: :get, class: 'form-filters', data:{turbo:true, turbo_frame:'frame_list_keywords'} do |form| %>
     <div>
-      <label for="keyword_pattern" class="form-label">
+      <%= form.label :keyword_pattern, class: 'form-label' do %>
         <i class="bi bi-list-check"></i> <%= t('filters.by_keyword') %>...
-      </label>
-      <input type="text" name="keyword_pattern" placeholder="type a keyword pattern" class="form-control"/>
+      <% end %>
+      <%= form.text_field :keyword_pattern, placeholder: 'type a keyword pattern', class: 'form-control' %>
     </div>
     <div>
-      <label for="url_pattern" class="form-label mt-3">
-        <i class="bi bi-link-45deg"></i> <%= t('filters.result_link') %>...
-      </label>
-      <input type="text" name="url_pattern" placeholder="type a url pattern" class="form-control"/>
+      <%= form.label :url_pattern, class: 'form-label mt-3' do %>
+        <i class="bi bi-link-45deg"></i>
+        <%= t('filters.result_link') %>...
+      <% end %>
+      <%= form.text_field :url_pattern, placeholder: 'type a url pattern', class: 'form-control' %>
     </div>
     <div class="mt-3">
-      <% ResultLink.link_types.each do |link_type| %>
-        <label>
-          <input type="checkbox" name="link_types[]" id='linkType<%= link_type[0].camelize %>' value="<%= link_type[0] %>">
-          <%= t("link_types.#{link_type[0]}") %>
-        </label>
+      <%= form.collection_check_boxes :link_types, ResultLink.link_types, :last, :first do |check_box| %>
+        <%= check_box.check_box %>
+        <%= check_box.label do %>
+          <%= t("link_types.#{check_box.text}") %>
+        <% end %>
       <% end %>
     </div>
     <div class="d-flex justify-content-end">
-      <button type="submit" class="btn btn-outline-primary mt-3 ">
-        <i class="bi bi-funnel"></i>
-        <%= t('filters.submit_btn') %>
-      </button>
+      <%= form.button t('filters.submit_btn'), class: 'btn btn-outline-primary mt-3' %>
     </div>
-  </form>
+  <% end %>
   <div class="form-text mt-3">
     <i class="bi bi-info-square"></i>
     <%= t('filters.cheatsheet') %>:
@@ -42,7 +40,9 @@
       <li class="list-group-item list-group-item-light"><code>a{2,}</code> 'aa', 'aaa', 'aaaa', ...</li>
       <li class="list-group-item list-group-item-light"><code>a{2,4}</code> 'aa', 'aaa' or 'aaaa'</li>
       <li class="list-group-item list-group-item-light"><code>(abc)?</code> 'abc' or ''</li>
-      <li class="list-group-item list-group-item-light"><code>[a-zA-Z]</code> '<%= t('filters.anyletterfromatoz') %>', ...</li>
+      <li class="list-group-item list-group-item-light"><code>[a-zA-Z]</code> '<%= t('filters.anyletterfromatoz') %>',
+        ...
+      </li>
     </ul>
   </div>
 <% end %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,3 +1,48 @@
 <%= turbo_frame_tag 'frame_filters' do %>
-  <p>You have a total of <%= keywords_count %> keywords.</p>
+  <p>
+    <%= t('filters.total_of_keywords', keywords_count: keywords_count) %>
+  </p>
+  <form action="<%= keywords_path %>" method="GET" class="form-filters" data-turbo="true" data-turbo-frame="frame_list_keywords">
+    <div>
+      <label for="keyword_pattern" class="form-label">
+        <i class="bi bi-list-check"></i> <%= t('filters.by_keyword') %>...
+      </label>
+      <input type="text" name="keyword_pattern" placeholder="type a keyword pattern" class="form-control"/>
+    </div>
+    <div>
+      <label for="url_pattern" class="form-label mt-3">
+        <i class="bi bi-link-45deg"></i> <%= t('filters.result_link') %>...
+      </label>
+      <input type="text" name="url_pattern" placeholder="type a url pattern" class="form-control"/>
+    </div>
+    <div class="mt-3">
+      <% ResultLink.link_types.each do |link_type| %>
+        <label>
+          <input type="checkbox" name="link_types[]" id='linkType<%= link_type[0].camelize %>' value="<%= link_type[0] %>">
+          <%= t("link_types.#{link_type[0]}") %>
+        </label>
+      <% end %>
+    </div>
+    <div class="d-flex justify-content-end">
+      <button type="submit" class="btn btn-outline-primary mt-3 ">
+        <i class="bi bi-funnel"></i>
+        <%= t('filters.submit_btn') %>
+      </button>
+    </div>
+  </form>
+  <div class="form-text mt-3">
+    <i class="bi bi-info-square"></i>
+    <%= t('filters.cheatsheet') %>:
+    <ul class="list-group">
+      <li class="list-group-item list-group-item-light"><code>a|b</code> 'a' or 'b'</li>
+      <li class="list-group-item list-group-item-light"><code>a*</code> '', 'a', 'aaaa', ...</li>
+      <li class="list-group-item list-group-item-light"><code>a+</code> 'a', 'aaaa', ...</li>
+      <li class="list-group-item list-group-item-light"><code>a?</code> 'a' or ''</li>
+      <li class="list-group-item list-group-item-light"><code>a{2}</code> 'aa'</li>
+      <li class="list-group-item list-group-item-light"><code>a{2,}</code> 'aa', 'aaa', 'aaaa', ...</li>
+      <li class="list-group-item list-group-item-light"><code>a{2,4}</code> 'aa', 'aaa' or 'aaaa'</li>
+      <li class="list-group-item list-group-item-light"><code>(abc)?</code> 'abc' or ''</li>
+      <li class="list-group-item list-group-item-light"><code>[a-zA-Z]</code> '<%= t('filters.anyletterfromatoz') %>', ...</li>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/keywords/_filters_keywords.html.erb
+++ b/app/views/keywords/_filters_keywords.html.erb
@@ -1,2 +1,2 @@
-<h5><%= t('filters') %></h5>
+<h5><%= t('filters.filters') %></h5>
 <%= render 'filters_keywords_body' %>

--- a/app/views/keywords/_filters_keywords_mobile.html.erb
+++ b/app/views/keywords/_filters_keywords_mobile.html.erb
@@ -1,6 +1,6 @@
 <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasFilters" aria-labelledby="offcanvasFiltersLabel">
   <div class="offcanvas-header">
-    <h5 class="offcanvas-title" id="offcanvasFiltersLabel"><%= t('filters') %></h5>
+    <h5 class="offcanvas-title" id="offcanvasFiltersLabel"><%= t('filters.filters') %></h5>
     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body">

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -14,11 +14,11 @@
         </div>
       </div>
     <% end %>
-    <% if keywords.groups.any? %>
+    <% if presenter.keyword_groups.any? %>
       <div class="d-flex justify-content-around">
         <%== pagy_bootstrap_nav(pagy) %>
       </div>
-      <% keywords.groups.each do |group_key, group_keywords| %>
+      <% presenter.keyword_groups.each do |group_key, group_keywords| %>
         <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
       <% end %>
     <% elsif filter_error.present? %>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,17 +1,19 @@
 <section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'frame_list_keywords' do %>
-    <div class="d-flex justify-content-end match-counts">
-      <div class="text-muted">
-        <div class="text-end match-counts--urls">
-        <%= url_match_count %>
-        <i class="bi bi-link-45deg"></i>
-        </div>
-        <div class="text-end match-counts--keywords">
-        <%= pagy.count %>
-        <i class="bi bi-list-check"></i>
+    <% if filter_error.blank? %>
+      <div class="d-flex justify-content-end match-counts">
+        <div class="text-muted">
+          <div class="text-end match-counts--urls">
+            <%= url_match_count %>
+            <i class="bi bi-link-45deg"></i>
+          </div>
+          <div class="text-end match-counts--keywords">
+            <%= pagy.count %>
+            <i class="bi bi-list-check"></i>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
     <% if keywords.groups.any? %>
       <div class="d-flex justify-content-around">
         <%== pagy_bootstrap_nav(pagy) %>
@@ -19,6 +21,8 @@
       <% keywords.groups.each do |group_key, group_keywords| %>
         <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
       <% end %>
+    <% elsif filter_error.present? %>
+      <div class="alert alert-danger"><%= filter_error %></div>
     <% else %>
       <div class="alert alert-light"><%= t('keywords.empty_list') %></div>
     <% end %>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,5 +1,17 @@
 <section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'frame_list_keywords' do %>
+    <div class="d-flex justify-content-end match-counts">
+      <div class="text-muted">
+        <div class="text-end match-counts--urls">
+        <%= url_match_count %>
+        <i class="bi bi-link-45deg"></i>
+        </div>
+        <div class="text-end match-counts--keywords">
+        <%= pagy.count %>
+        <i class="bi bi-list-check"></i>
+        </div>
+      </div>
+    </div>
     <% if keywords.groups.any? %>
       <div class="d-flex justify-content-around">
         <%== pagy_bootstrap_nav(pagy) %>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,13 +1,13 @@
 <section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'frame_list_keywords' do %>
     <% if filter_error.blank? %>
-      <div class="d-flex justify-content-end match-counts">
+      <div class="d-flex justify-content-end match-count">
         <div class="text-muted">
-          <div class="text-end match-counts--urls">
+          <div class="text-end match-count--urls">
             <%= url_match_count %>
             <i class="bi bi-link-45deg"></i>
           </div>
-          <div class="text-end match-counts--keywords">
+          <div class="text-end match-count--keywords">
             <%= pagy.count %>
             <i class="bi bi-list-check"></i>
           </div>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -3,11 +3,11 @@
     <% if filter_error.blank? %>
       <div class="d-flex justify-content-end match-count">
         <div class="text-muted">
-          <div class="text-end match-count--urls">
+          <div class="text-end match-count--url">
             <%= url_match_count %>
             <i class="bi bi-link-45deg"></i>
           </div>
-          <div class="text-end match-count--keywords">
+          <div class="text-end match-count--keyword">
             <%= pagy.count %>
             <i class="bi bi-list-check"></i>
           </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -7,7 +7,7 @@
       <%= turbo_stream_from "card_search_progress_stream:user_#{current_user.id}" %>
       <%= turbo_frame_tag 'card_search_progress' do %>
       <% end %>
-      <%= render 'list_keywords', keywords: keywords, pagy: pagy, url_match_count: url_match_count, filter_error: filter_error %>
+      <%= render 'list_keywords', presenter: presenter, pagy: pagy, url_match_count: url_match_count, filter_error: filter_error %>
 
       <%= turbo_frame_tag 'frame_keyword_show' do %>
       <% end %>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -7,7 +7,7 @@
       <%= turbo_stream_from "card_search_progress_stream:user_#{current_user.id}" %>
       <%= turbo_frame_tag 'card_search_progress' do %>
       <% end %>
-      <%= render 'list_keywords', keywords: keywords, pagy: pagy %>
+      <%= render 'list_keywords', keywords: keywords, pagy: pagy, url_match_count: url_match_count %>
 
       <%= turbo_frame_tag 'frame_keyword_show' do %>
       <% end %>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -7,7 +7,7 @@
       <%= turbo_stream_from "card_search_progress_stream:user_#{current_user.id}" %>
       <%= turbo_frame_tag 'card_search_progress' do %>
       <% end %>
-      <%= render 'list_keywords', keywords: keywords, pagy: pagy, url_match_count: url_match_count %>
+      <%= render 'list_keywords', keywords: keywords, pagy: pagy, url_match_count: url_match_count, filter_error: filter_error %>
 
       <%= turbo_frame_tag 'frame_keyword_show' do %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,11 +35,11 @@ en:
     token_revoked: 'If your token was valid, it has been revoked'
   keywords:
     could_not_query: 'An error occurs when performing the Google Search, please try again.'
-    empty_list: 'You do not have any keyword yet.'
     parsed: 'keywords parsed'
     failed: 'failed being retried'
     parsing_progress: 'Parsing is in progress'
     keywords_left: 'keywords left'
+    empty_list: 'No keyword found. Upload a CSV file to add more keywords.'
     status:
       pending: 'Pending'
       failed: 'Failed'
@@ -48,6 +48,10 @@ en:
     non_ads: 'Non ad links'
     ads_page: 'Page ad links'
     ads_top: 'Top ad links'
+  link_types:
+    ads_top: 'Top ads'
+    ads_page: 'Page ads'
+    non_ads: 'Non ads'
   pagy:
     errors:
       overflow: 'There are not that many pages here! Max page is %{max_page}'
@@ -79,5 +83,11 @@ en:
   filters:
     filters: 'Filters'
     value_error: 'has wrong value'
+    total_of_keywords: "You have a total of %{keywords_count} keywords"
+    by_keyword: 'By keyword'
+    by_result_link: 'By result link'
+    submit_btn: 'Apply'
+    cheatsheet: 'Patterns cheatsheet'
+    anyletterfromatoz: 'AnyLetterFromAToZ'
   loading: 'Loading'
   record_not_found: 'The requested resource could not be found.'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,4 +37,6 @@ RSpec.configure do |config|
   config.include SearchProgressHelpers::System
 
   config.include ChannelHelpers
+
+  config.include KeywordFiltersHelpers::System
 end

--- a/spec/support/keyword_filters_helpers.rb
+++ b/spec/support/keyword_filters_helpers.rb
@@ -10,7 +10,7 @@ module KeywordFiltersHelpers
       fill_in :keyword_pattern, with: params[:keyword_pattern]
       fill_in :url_pattern, with: params[:url_pattern]
 
-      params[:link_types]&.each { |link_type| check "linkType#{link_type.to_s.camelize}" }
+      params[:link_types]&.each { |link_type| check "link_types_#{link_type}" }
 
       click_button I18n.t('filters.submit_btn')
     end

--- a/spec/support/keyword_filters_helpers.rb
+++ b/spec/support/keyword_filters_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module KeywordFiltersHelpers
+  module System
+    def submit_keyword_filters(user, params = {})
+      sign_in user
+
+      visit root_path
+
+      fill_in :keyword_pattern, with: params[:keyword_pattern]
+      fill_in :url_pattern, with: params[:url_pattern]
+
+      params[:link_types]&.each { |link_type| check "linkType#{link_type.to_s.camelize}" }
+
+      click_button I18n.t('filters.submit_btn')
+    end
+  end
+end

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -13,7 +13,7 @@ describe 'keywords filters', type: :system do
 
       visit root_path
 
-      expect(find('.match-count--keywords')).to have_content(5)
+      expect(find('.match-count--keyword')).to have_content(5)
     end
 
     it 'shows the matched result_links count' do
@@ -25,37 +25,37 @@ describe 'keywords filters', type: :system do
 
       visit root_path
 
-      expect(find('.match-count--urls')).to have_content(5)
+      expect(find('.match-count--url')).to have_content(5)
     end
 
     it 'has a filter form', authenticated_user: true do
       visit root_path
 
-      expect(page).to have_selector('.form-filters')
+      expect(page).to have_selector('.form-filter')
     end
 
     it 'has a keyword_pattern input', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filters')).to have_selector('input[name=keyword_pattern]')
+      expect(find('.form-filter')).to have_selector('input[name=keyword_pattern]')
     end
 
     it 'has a url_pattern input', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filters')).to have_selector('input[name=url_pattern]')
+      expect(find('.form-filter')).to have_selector('input[name=url_pattern]')
     end
 
     it 'has all the link_types checkboxes', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filters')).to have_selector('input[type=checkbox][name=link_types\[\]]', count: ResultLink.link_types.length)
+      expect(find('.form-filter')).to have_selector('input[type=checkbox][name=link_types\[\]]', count: ResultLink.link_types.length)
     end
 
     it 'has a submit button', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filters button[type=submit]')).to have_content(I18n.t('filters.submit_btn'))
+      expect(find('.form-filter button[type=submit]')).to have_content(I18n.t('filters.submit_btn'))
     end
 
     it 'does NOT have any error message', authenticated_user: true do

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -13,7 +13,7 @@ describe 'keywords filters', type: :system do
 
       visit root_path
 
-      expect(find('.match-counts--keywords')).to have_content(5)
+      expect(find('.match-count--keywords')).to have_content(5)
     end
 
     it 'shows the matched result_links count' do
@@ -25,7 +25,7 @@ describe 'keywords filters', type: :system do
 
       visit root_path
 
-      expect(find('.match-counts--urls')).to have_content(5)
+      expect(find('.match-count--urls')).to have_content(5)
     end
 
     it 'has a filter form', authenticated_user: true do

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -114,7 +114,7 @@ describe 'keywords filters', type: :system do
       matched_keyword = Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :ads_top).keyword
       Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :non_ads)
 
-      submit_keyword_filters(user, { link_types: [:ads_top] })
+      submit_keyword_filters(user, { link_types: [ResultLink.link_types[:ads_top]] })
 
       expect(find('.list-keyword')).to have_content(matched_keyword.name)
     end
@@ -125,7 +125,7 @@ describe 'keywords filters', type: :system do
       Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :ads_top)
       unmatched_keyword = Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :non_ads).keyword
 
-      submit_keyword_filters(user, { link_types: [:ads_top] })
+      submit_keyword_filters(user, { link_types: [ResultLink.link_types[:ads_top]] })
 
       expect(find('.list-keyword')).not_to have_content(unmatched_keyword.name)
     end

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'keywords filters', type: :system do
+  context 'given no filters' do
+    it 'shows the matched keywords count' do
+      user = Fabricate(:user)
+
+      Fabricate.times(5, :keyword, user: user)
+
+      sign_in user
+
+      visit root_path
+
+      expect(find('.match-counts--keywords')).to have_content(5)
+    end
+
+    it 'shows the matched result_links count' do
+      keyword = Fabricate(:keyword)
+
+      Fabricate.times(5, :result_link, keyword: keyword)
+
+      sign_in keyword.user
+
+      visit root_path
+
+      expect(find('.match-counts--urls')).to have_content(5)
+    end
+
+    it 'has a filter form', authenticated_user: true do
+      visit root_path
+
+      expect(page).to have_selector('.form-filters')
+    end
+
+    it 'has a keyword_pattern input', authenticated_user: true do
+      visit root_path
+
+      expect(find('.form-filters')).to have_selector('input[name=keyword_pattern]')
+    end
+
+    it 'has a url_pattern input', authenticated_user: true do
+      visit root_path
+
+      expect(find('.form-filters')).to have_selector('input[name=url_pattern]')
+    end
+
+    it 'has all the link_types checkboxes', authenticated_user: true do
+      visit root_path
+
+      expect(find('.form-filters')).to have_selector('input[type=checkbox][name=link_types\[\]]', count: ResultLink.link_types.length)
+    end
+
+    it 'has a submit button', authenticated_user: true do
+      visit root_path
+
+      expect(find('.form-filters button[type=submit]')).to have_content(I18n.t('filters.submit_btn'))
+    end
+  end
+
+  context 'given a keyword_pattern param' do
+    it 'displays the matched keywords' do
+      user = Fabricate(:user)
+
+      matched_keyword = Fabricate(:keyword, user: user, name: 'Construction')
+      Fabricate(:keyword, user: user, name: 'castor')
+
+      submit_keyword_filters(user, { keyword_pattern: '^co' })
+
+      expect(find('.list-keyword')).to have_content(matched_keyword.name)
+    end
+
+    it 'does NOT display the unmatched keywords' do
+      user = Fabricate(:user)
+
+      Fabricate(:keyword, user: user, name: 'Construction')
+      unmatched_keyword = Fabricate(:keyword, user: user, name: 'castor')
+
+      submit_keyword_filters(user, { keyword_pattern: '^co' })
+
+      expect(find('.list-keyword')).not_to have_content(unmatched_keyword.name)
+    end
+  end
+
+  context 'given a url_pattern param' do
+    it 'displays the matched keywords' do
+      matched_keyword = Fabricate(:keyword, name: 'Construction')
+
+      Fabricate(:result_link, keyword: matched_keyword, url: 'www3.new-web.world')
+      Fabricate(:keyword_parsed_with_links, user: matched_keyword.user, name: 'castor')
+
+      submit_keyword_filters(matched_keyword.user, { url_pattern: '^www3.' })
+
+      expect(find('.list-keyword')).to have_content(matched_keyword.name)
+    end
+
+    it 'does NOT display the unmatched keywords' do
+      unmatched_keyword = Fabricate(:keyword, name: 'Construction')
+
+      Fabricate(:result_link, keyword: unmatched_keyword, url: 'www3.new-web.world')
+      Fabricate(:keyword_parsed_with_links, user: unmatched_keyword.user, name: 'castor')
+
+      submit_keyword_filters(unmatched_keyword.user, { url_pattern: '^http' })
+
+      expect(find('.list-keyword')).not_to have_content(unmatched_keyword.name)
+    end
+  end
+
+  context 'given a link_types param' do
+    it 'displays the matched keywords' do
+      user = Fabricate(:user)
+
+      matched_keyword = Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :ads_top).keyword
+      Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :non_ads)
+
+      submit_keyword_filters(user, { link_types: [:ads_top] })
+
+      expect(find('.list-keyword')).to have_content(matched_keyword.name)
+    end
+
+    it 'does NOT display the unmatched keywords' do
+      user = Fabricate(:user)
+
+      Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :ads_top)
+      unmatched_keyword = Fabricate(:result_link, keyword: Fabricate(:keyword_parsed, user: user), link_type: :non_ads).keyword
+
+      submit_keyword_filters(user, { link_types: [:ads_top] })
+
+      expect(find('.list-keyword')).not_to have_content(unmatched_keyword.name)
+    end
+  end
+
+  context 'given filters with no match' do
+    it 'shows the keywords.empty_list message' do
+      user = Fabricate(:user)
+
+      Fabricate(:keyword, user: user, name: 'hello')
+      Fabricate(:keyword, user: user, name: 'world')
+
+      submit_keyword_filters(user, { keyword_pattern: 'no_match' })
+
+      expect(find('.list-keyword')).to have_content(I18n.t('keywords.empty_list'))
+    end
+  end
+end


### PR DESCRIPTION
- #15 

## What happened

- [x] Add views for filter form and match counts
- [x] Use locals instead of hardcoded english in views
- [x] Add system tests
- [x] Add tests to handle error handling
- [x] Review code after these changes

## Insight

- Filter view:
    - update existing containers set in #57 
    - the form is set to submit via `turbo` (hotwire) and to refresh the `frame_list_keywords` turbo frame:
    `data-turbo="true" data-turbo-frame="frame_list_keywords"`
- match counts view:
    - simply add 2x counts: `url_match_count` (from #10 ) and `pagy.count` (containing the total number keywords across all pages)
- System tests covers the following
    - form & counts presence
    - basic queries
    - no result when querying

## Proof Of Work

### System Tests

![image](https://user-images.githubusercontent.com/77609814/127295376-490a4334-1933-41eb-a14f-447d1e8b259d.png)

### Overview

- on the left: Filter panel with keyword_pattern, url_pattern and link_type check_boxes
- on the top-right corner: matching counts for keywords & result-links
![image](https://user-images.githubusercontent.com/77609814/126732876-1091730b-3619-4c49-8cc0-7acf5d9411c7.png)

### Detailed:

| Empty filter form | Filled in form |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/126733024-77071efb-fecd-4ea9-8831-6c7e4da4c52f.png) ![image](https://user-images.githubusercontent.com/77609814/126733170-32ccd6a9-14fa-4a4a-b24b-bffdb32f187e.png) | ![image](https://user-images.githubusercontent.com/77609814/126733116-cbcfd3b7-6aa7-46bf-af94-0f1a625a01f6.png) ![image](https://user-images.githubusercontent.com/77609814/126733139-a5efe0cf-1bb2-410a-9a5b-e653e8e6ce3c.png) |

### Pagination embed filters:
![image](https://user-images.githubusercontent.com/77609814/126733623-117e28ff-04b2-4276-ae9a-c229023acaae.png)

> to my surprise, pagy handles current GET requests params and includes them in the pagination links, making the code clean and light :) 
![image](https://user-images.githubusercontent.com/77609814/126733710-165078f7-5b37-42f3-9d9c-59528ec31f47.png)





