### PR TITLE
[#89] [Chore] As a developer, I can download the screenshot of failed system tests from Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,10 @@ jobs:
 
       - name: Run system tests
         run: docker-compose run test bundle exec rspec spec/systems --profile
+
+      - name: Upload Rspec Screenshots Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: system_tests_screenshots
+          path: tmp/screenshots/*


### PR DESCRIPTION
- #89 

## What happened

Add upload artifacts step in the test.yml GitHub action
Same change as rails-template implementation [here #300](https://github.com/nimblehq/rails-templates/pull/300).

## Insight

- Run a test workflow with failing system tests
- Screenshots of failing tests will be available in the GitHub Action summary page

## Proof Of Work

Here is [an example](https://github.com/malparty/google-search-ruby/actions/runs/1088710175): 

![image](https://user-images.githubusercontent.com/77609814/127836744-f15fdbbf-01e9-432b-88d7-9a66108cf0c5.png)
