### PR TITLE
#87 [Backend] As a user, I can save/share a filtered view from its URL

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -3,7 +3,14 @@
 class FiltersController < ApplicationController
   def index
     render locals: {
-      keywords_count: current_user.keywords.count
+      keywords_count: current_user.keywords.count,
+      filter: Filter.from_params(index_params)
     }
+  end
+
+  private
+
+  def index_params
+    params.permit(Filter::QUERY_PARAMS)
   end
 end

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -10,7 +10,7 @@ class KeywordsController < ApplicationController
       pagy: pagy,
       presenter: KeywordsCollectionPresenter.new(keywords_list),
       url_match_count: keywords_query.url_match_count,
-      filter_error: keywords_query.error,
+      filter: keywords_query.filter,
       csv_form: csv_form
     }
   end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -24,6 +24,10 @@ class Filter
     url_pattern.present? || link_types.present?
   end
 
+  def error_message
+    errors.full_messages.join '. '
+  end
+
   protected
 
   def link_types_exist?

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -3,7 +3,7 @@
 class Filter
   include ActiveModel::Model
 
-  QUERY_PARAMS = [:url_pattern, :keyword_pattern, { link_types: [] }].freeze
+  QUERY_PARAMS = [filter: [:url_pattern, :keyword_pattern, { link_types: [] }]].freeze
   PATTERN_REGEXP =
     %r{\A\^?((\[[\\\-/:.\w]+\])|([\\\-/:.\w]+)|(\(([\\\-/:.\w]+)\|?([\\\-/:.\w]+)\)))[+?*]?(\{\d+(,\d?)?\})?\$?\Z}
     .freeze
@@ -15,9 +15,11 @@ class Filter
   validate :link_types_exist?
 
   def self.from_params(params)
-    Filter.new keyword_pattern: params[:keyword_pattern],
-               url_pattern: params[:url_pattern],
-               link_types: params[:link_types]&.select(&:present?)&.map(&:to_i)&.uniq
+    return Filter.new unless params.key?(:filter)
+
+    Filter.new keyword_pattern: params[:filter][:keyword_pattern],
+               url_pattern: params[:filter][:url_pattern],
+               link_types: params[:filter][:link_types]&.select(&:present?)&.map(&:to_i)&.uniq
   end
 
   def result_link_filter_exist?

--- a/app/queries/keywords_query.rb
+++ b/app/queries/keywords_query.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class KeywordsQuery
+  attr_reader :filter
+
   def initialize(relation, filter_params = {})
     @relation = relation
     @filter = Filter.from_params(filter_params)
@@ -23,13 +25,9 @@ class KeywordsQuery
     result_links_filtered.count
   end
 
-  def error
-    filter.errors.full_messages.join '. '
-  end
-
   private
 
-  attr_reader :relation, :filter
+  attr_reader :relation
 
   def without_html_column(scope)
     scope.select(Keyword.column_names.excluding('html'))

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= t('filters.total_of_keywords', keywords_count: keywords_count) %>
   </p>
-  <%= form_with url: keywords_path, method: :get, class: 'form-filter', data: { turbo: true, turbo_frame: 'frame_list_keywords' } do |form| %>
+  <%= form_with model: filter, url: keywords_path, method: :get, class: 'form-filter', data: { turbo: true, turbo_frame: 'frame_list_keywords' } do |form| %>
     <div>
       <%= form.label :keyword_pattern, class: 'form-label' do %>
         <i class="bi bi-list-check"></i> <%= t('filters.by_keyword') %>...

--- a/app/views/keywords/_filters_keywords.html.erb
+++ b/app/views/keywords/_filters_keywords.html.erb
@@ -1,2 +1,2 @@
 <h5><%= t('filters.filters') %></h5>
-<%= render 'filters_keywords_body' %>
+<%= render 'filters_keywords_body', filter: filter %>

--- a/app/views/keywords/_filters_keywords_body.html.erb
+++ b/app/views/keywords/_filters_keywords_body.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag 'frame_filters', loading: "lazy", src: filters_path do %>
+<%= turbo_frame_tag 'frame_filters', loading: "lazy", src: filters_path(filter: filter.as_json) do %>
   <div class="d-flex justify-content-center">
     <div class="spinner-border text-primary" role="status">
       <span class="visually-hidden"><%= t('loading') %>...</span>

--- a/app/views/keywords/_filters_keywords_mobile.html.erb
+++ b/app/views/keywords/_filters_keywords_mobile.html.erb
@@ -4,6 +4,6 @@
     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body">
-    <%= render 'filters_keywords_body' %>
+    <%= render 'filters_keywords_body', filter: filter %>
   </div>
 </div>

--- a/app/views/keywords/_list_keywords.html.erb
+++ b/app/views/keywords/_list_keywords.html.erb
@@ -1,6 +1,6 @@
 <section class="list-keyword" data-turbo="true">
   <%= turbo_frame_tag 'frame_list_keywords' do %>
-    <% if filter_error.blank? %>
+    <% if filter.errors.blank? %>
       <div class="d-flex justify-content-end match-count">
         <div class="text-muted">
           <div class="text-end match-count--url">
@@ -21,8 +21,8 @@
       <% presenter.keyword_groups.each do |group_key, group_keywords| %>
         <%= render 'list_keywords_group', group_key: group_key, group_keywords: group_keywords %>
       <% end %>
-    <% elsif filter_error.present? %>
-      <div class="alert alert-danger"><%= filter_error %></div>
+    <% elsif filter.errors.any? %>
+      <div class="alert alert-danger"><%= filter.error_message %></div>
     <% else %>
       <div class="alert alert-light"><%= t('keywords.empty_list') %></div>
     <% end %>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,13 +1,13 @@
 <div class="container-xl screen-keyword">
   <div class="row">
     <div class="col-md-4 col-lg-3 d-md-block d-none">
-      <%= render 'filters_keywords' %>
+      <%= render 'filters_keywords', filter: filter %>
     </div>
     <div class="col-md-8 col-lg-9">
       <%= turbo_stream_from "card_search_progress_stream:user_#{current_user.id}" %>
       <%= turbo_frame_tag 'card_search_progress' do %>
       <% end %>
-      <%= render 'list_keywords', presenter: presenter, pagy: pagy, url_match_count: url_match_count, filter_error: filter.error_message %>
+      <%= render 'list_keywords', presenter: presenter, pagy: pagy, url_match_count: url_match_count, filter: filter %>
 
       <%= turbo_frame_tag 'frame_keyword_show' do %>
       <% end %>
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-<%= render 'filters_keywords_mobile' %>
+<%= render 'filters_keywords_mobile', filter: filter %>
 
 <% content_for :header_nav_bar do %>
   <%= render 'form_upload', csv_form: csv_form %>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -7,7 +7,7 @@
       <%= turbo_stream_from "card_search_progress_stream:user_#{current_user.id}" %>
       <%= turbo_frame_tag 'card_search_progress' do %>
       <% end %>
-      <%= render 'list_keywords', presenter: presenter, pagy: pagy, url_match_count: url_match_count, filter_error: filter_error %>
+      <%= render 'list_keywords', presenter: presenter, pagy: pagy, url_match_count: url_match_count, filter_error: filter.error_message %>
 
       <%= turbo_frame_tag 'frame_keyword_show' do %>
       <% end %>

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe KeywordsQuery, type: :query do
         Fabricate.times(10, :keyword_parsed_with_links, user: users[0])
         Fabricate.times(15, :keyword_parsed_with_links, user: users[1])
 
-        query = described_class.new(users[0].keywords, { url_pattern: '.*' })
+        query = described_class.new(users[0].keywords, { filter: { url_pattern: '.*' } })
 
         expect(query.url_match_count).to eq(users[0].keywords.sum { |keyword| keyword.result_links.count })
       end
@@ -63,7 +63,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         %w[World awesome Pool].each { |name| Fabricate(:keyword, user: user, name: name) }
 
-        query = described_class.new(user.keywords, { keyword_pattern: 'awesome' })
+        query = described_class.new(user.keywords, { filter: { keyword_pattern: 'awesome' } })
 
         expect(query.keywords_filtered.map(&:name)).to eq(%w[awesome])
       end
@@ -73,7 +73,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         %w[World awesome Pool].each { |name| Fabricate(:keyword, user: user, name: name) }
 
-        query = described_class.new(user.keywords, { keyword_pattern: 'pooL' })
+        query = described_class.new(user.keywords, { filter: { keyword_pattern: 'pooL' } })
 
         expect(query.keywords_filtered.map(&:name)).to eq(%w[Pool])
       end
@@ -85,7 +85,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         %w[World awesome Pool Zipline Zoo].each { |name| Fabricate(:keyword, user: user, name: name) }
 
-        query = described_class.new(user.keywords, { keyword_pattern: 'o{2}' })
+        query = described_class.new(user.keywords, { filter: { keyword_pattern: 'o{2}' } })
 
         expect(query.keywords_filtered.map(&:name)).to eq(%w[Pool Zoo])
       end
@@ -99,7 +99,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
 
-        query = described_class.new(keyword.user.keywords, { url_pattern: 'https://beautiful-table.com/zaxs' })
+        query = described_class.new(keyword.user.keywords, { filter: { url_pattern: 'https://beautiful-table.com/zaxs' } })
 
         expect(query.keywords_filtered.map(&:name)).to eq([keyword.name])
       end
@@ -111,7 +111,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
 
-        query = described_class.new(keyword.user.keywords, { url_pattern: '.com\/zaxs$' })
+        query = described_class.new(keyword.user.keywords, { filter: { url_pattern: '.com\/zaxs$' } })
 
         expect(query.keywords_filtered.map(&:name)).to eq([keyword.name])
       end
@@ -121,7 +121,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
 
-        query = described_class.new(keyword.user.keywords, { url_pattern: '.com\/zaxs$' })
+        query = described_class.new(keyword.user.keywords, { filter: { url_pattern: '.com\/zaxs$' } })
 
         expect(query.url_match_count).to eq(1)
       end
@@ -131,7 +131,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs')
 
-        query = described_class.new(keyword.user.keywords, { url_pattern: '.com\/zaxs$' })
+        query = described_class.new(keyword.user.keywords, { filter: { url_pattern: '.com\/zaxs$' } })
 
         expect(query.filter.error_message).to be_blank
       end
@@ -146,7 +146,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       keyword.update(name: 'world')
 
-      query = described_class.new(keyword.user.keywords, { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' })
+      query = described_class.new(keyword.user.keywords, { filter: { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' } })
 
       expect(query.keywords_filtered.map(&:name)).to eq([keyword.name])
     end
@@ -156,7 +156,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       keywords.take(2).each { |keyword| keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs') }
 
-      query = described_class.new(keywords[0].user.keywords, { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' })
+      query = described_class.new(keywords[0].user.keywords, { filter: { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' } })
 
       expect(query.keywords_filtered.map(&:name)).to eq(%w[world world])
     end
@@ -166,7 +166,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       keywords.take(2).each { |keyword| keyword.result_links[0].update(url: 'https://beautiful-table.com/zaxs') }
 
-      query = described_class.new(keywords[0].user.keywords, { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' })
+      query = described_class.new(keywords[0].user.keywords, { filter: { keyword_pattern: 'WOR.+', url_pattern: '.com\/zaxs$' } })
 
       expect(query.url_match_count).to eq(2)
     end
@@ -179,7 +179,7 @@ RSpec.describe KeywordsQuery, type: :query do
       Fabricate.times(5, :keyword_parsed, user: user).each { |keyword| Fabricate(:result_link, keyword: keyword, link_type: :ads_top) }
       Fabricate.times(10, :keyword_parsed, user: user).each { |keyword| Fabricate(:result_link, keyword: keyword, link_type: :non_ads) }
 
-      query = described_class.new(user.keywords, { link_types: [ResultLink.link_types[:ads_top].to_s] })
+      query = described_class.new(user.keywords, { filter: { link_types: [ResultLink.link_types[:ads_top].to_s] } })
 
       expect(query.url_match_count).to eq(5)
     end
@@ -190,7 +190,7 @@ RSpec.describe KeywordsQuery, type: :query do
       Fabricate.times(5, :keyword_parsed, user: user).each { |keyword| Fabricate(:result_link, keyword: keyword, link_type: :ads_top) }
       Fabricate.times(10, :keyword_parsed, user: user).each { |keyword| Fabricate(:result_link, keyword: keyword, link_type: :non_ads) }
 
-      query = described_class.new(user.keywords, { link_types: [ResultLink.link_types[:ads_top].to_s] })
+      query = described_class.new(user.keywords, { filter: { link_types: [ResultLink.link_types[:ads_top].to_s] } })
 
       expect(query.keywords_filtered.length).to eq(5)
     end
@@ -202,7 +202,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       Fabricate.times(10, :result_link_with_keyword, keyword: keyword, link_type: %i[ads_top non_ads].sample)
 
-      query = described_class.new(keyword.user.keywords, { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] })
+      query = described_class.new(keyword.user.keywords, { filter: { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] } })
 
       expect(query.url_match_count).to eq(10)
     end
@@ -213,7 +213,7 @@ RSpec.describe KeywordsQuery, type: :query do
       Fabricate.times(10, :result_link_with_keyword, keyword: keyword, link_type: %i[ads_top non_ads].sample)
       Fabricate.times(5, :result_link_with_keyword, keyword: keyword, link_type: :ads_page)
 
-      query = described_class.new(keyword.user.keywords, { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] })
+      query = described_class.new(keyword.user.keywords, { filter: { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] } })
 
       expect(query.url_match_count).to eq(10)
     end
@@ -224,7 +224,7 @@ RSpec.describe KeywordsQuery, type: :query do
       Fabricate.times(5, :result_link_with_keyword, keyword: keyword, link_type: %i[ads_top non_ads].sample)
       Fabricate.times(5, :result_link_with_keyword, keyword: Fabricate(:keyword_parsed), link_type: :ads_page)
 
-      query = described_class.new(keyword.user.keywords, { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] })
+      query = described_class.new(keyword.user.keywords, { filter: { link_types: [ResultLink.link_types[:ads_top].to_s, ResultLink.link_types[:non_ads].to_s] } })
 
       expect(query.keywords_filtered.length).to eq(1)
     end
@@ -236,7 +236,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       Fabricate.times(10, :keyword, user: user)
 
-      query = described_class.new(user.keywords, { url_pattern: '?', keyword_pattern: '?' })
+      query = described_class.new(user.keywords, { filter: { url_pattern: '?', keyword_pattern: '?' } })
 
       expect(query.keywords_filtered.length).to be_zero
     end
@@ -246,7 +246,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       Fabricate.times(10, :keyword, user: user)
 
-      query = described_class.new(user.keywords, { url_pattern: '?', keyword_pattern: '?' })
+      query = described_class.new(user.keywords, { filter: { url_pattern: '?', keyword_pattern: '?' } })
 
       expect(query.url_match_count).to be_zero
     end
@@ -256,7 +256,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       Fabricate.times(10, :keyword, user: user)
 
-      query = described_class.new(user.keywords, { url_pattern: '?', keyword_pattern: '?' })
+      query = described_class.new(user.keywords, { filter: { url_pattern: '?', keyword_pattern: '?' } })
 
       query.keywords_filtered
 

--- a/spec/queries/keywords_query_spec.rb
+++ b/spec/queries/keywords_query_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
         query = described_class.new(keyword.user.keywords, { url_pattern: '.com\/zaxs$' })
 
-        expect(query.error).to be_blank
+        expect(query.filter.error_message).to be_blank
       end
     end
   end
@@ -260,7 +260,7 @@ RSpec.describe KeywordsQuery, type: :query do
 
       query.keywords_filtered
 
-      expect(query.error).to be_present
+      expect(query.filter.error_message).to be_present
     end
   end
 end

--- a/spec/support/keyword_filters_helpers.rb
+++ b/spec/support/keyword_filters_helpers.rb
@@ -7,10 +7,10 @@ module KeywordFiltersHelpers
 
       visit root_path
 
-      fill_in :keyword_pattern, with: params[:keyword_pattern]
-      fill_in :url_pattern, with: params[:url_pattern]
+      fill_in :filter_keyword_pattern, with: params[:keyword_pattern]
+      fill_in :filter_url_pattern, with: params[:url_pattern]
 
-      params[:link_types]&.each { |link_type| check "link_types_#{link_type}" }
+      params[:link_types]&.each { |link_type| check "filter_link_types_#{link_type}" }
 
       click_button I18n.t('filters.submit_btn')
     end

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -196,4 +196,46 @@ describe 'keywords filters', type: :system do
       expect(find('.list-keyword')).to have_content('Url pattern is invalid')
     end
   end
+
+  context 'given a URL with filter params' do
+    it 'shows the matched keyword' do
+      matched_keyword = Fabricate(:keyword, name: 'hello')
+      Fabricate(:keyword, name: 'world', user: matched_keyword.user)
+
+      sign_in matched_keyword.user
+
+      visit root_path(filter: { keyword_pattern: '^hel' })
+
+      expect(find('.list-keyword')).to have_content(matched_keyword.name)
+    end
+
+    it 'does NOT show the unmatched keyword' do
+      unmatched_keyword = Fabricate(:keyword, name: 'hello')
+      Fabricate(:keyword, name: 'world', user: unmatched_keyword.user)
+
+      sign_in unmatched_keyword.user
+
+      visit root_path(filter: { keyword_pattern: '^wor' })
+
+      expect(find('.list-keyword')).not_to have_content(unmatched_keyword.name)
+    end
+
+    it 'fills keyword_pattern in', authenticated_user: true do
+      visit root_path(filter: { keyword_pattern: '^hel' })
+
+      expect(find('.form-filter')).to have_field('filter[keyword_pattern]', with: '^hel')
+    end
+
+    it 'fills url_pattern in', authenticated_user: true do
+      visit root_path(filter: { url_pattern: '^https' })
+
+      expect(find('.form-filter')).to have_field('filter[url_pattern]', with: '^https')
+    end
+
+    it 'fills link_types in', authenticated_user: true do
+      visit root_path(filter: { link_types: %w[1] })
+
+      expect(find('.form-filter #filter_link_types_1')).to be_checked
+    end
+  end
 end

--- a/spec/systems/keywords_filters_spec.rb
+++ b/spec/systems/keywords_filters_spec.rb
@@ -37,19 +37,19 @@ describe 'keywords filters', type: :system do
     it 'has a keyword_pattern input', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filter')).to have_selector('input[name=keyword_pattern]')
+      expect(find('.form-filter')).to have_selector('input[name=filter\[keyword_pattern\]]')
     end
 
     it 'has a url_pattern input', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filter')).to have_selector('input[name=url_pattern]')
+      expect(find('.form-filter')).to have_selector('input[name=filter\[url_pattern\]]')
     end
 
     it 'has all the link_types checkboxes', authenticated_user: true do
       visit root_path
 
-      expect(find('.form-filter')).to have_selector('input[type=checkbox][name=link_types\[\]]', count: ResultLink.link_types.length)
+      expect(find('.form-filter')).to have_selector('input[type=checkbox][name=filter\[link_types\]\[\]]', count: ResultLink.link_types.length)
     end
 
     it 'has a submit button', authenticated_user: true do


### PR DESCRIPTION
- #87 

## What happened

Add filter object to `keywords#index` and `filters#index` locals.

## Insight

- Filter params have been changed only in the FrontEnd PR #94  in order to ensure each branch can pass all tests
- This PR simply adds a full 'Filter' object into the locals. We will cover it with system tests in #94 

## Proof Of Work

- Test are passing (including error messages consumed from the `filter` local)